### PR TITLE
Adjusted RPC start value fixing Sheriff bug

### DIFF
--- a/source/Patches/CustomRPC.cs
+++ b/source/Patches/CustomRPC.cs
@@ -2,7 +2,7 @@ namespace TownOfUs
 {
     public enum CustomRPC
     {
-        SetJester = 43,
+        SetJester = 50,
         SetCouple,
         SetMayor,
         SetSheriff,


### PR DESCRIPTION
Pretty simple. Whenever an RPC call with value 0x23 (46) was issued it banned the player. This was found by searching for "Sheriff" in the code, finding this RPC call, and noticing that it was always sent in games where I would be insta-banned. Among Us almost certainly had to add more RPC calls to incorporate their new roles and as such 46 is probably now used when it wasn't before.

**TEST THIS WITH ALL ROLES** as perhaps there are more RPC call conflicts and an even higher start number would need to be used in that situation.