### PR TITLE
Changed Medbay scan to measure Giant players correctly

### DIFF
--- a/source/Patches/Tasks/Medbay.cs
+++ b/source/Patches/Tasks/Medbay.cs
@@ -1,0 +1,24 @@
+using System;
+using HarmonyLib;
+
+namespace TownOfUs.Tasks
+{
+	internal class BigBoiMedScan
+	{
+
+		[HarmonyPatch(typeof(MedScanMinigame))]
+		private static class MedScanMinigamePatch
+		{
+			[HarmonyPatch(nameof(MedScanMinigame.Begin))]
+			[HarmonyPostfix]
+			private static void BeginPostfix(MedScanMinigame __instance)
+			{
+                // Update medical details for Giant modifier
+                if (PlayerControl.LocalPlayer.Is(ModifierEnum.BigBoi))
+                {
+					__instance.completeString = __instance.completeString.Replace("3' 6\"", "5' 0\"").Replace("92lb", "188lb");
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
I've made a modification to the medbay scan so it shows more accurate weight and heights for giant players.
Giant player:
![image](https://user-images.githubusercontent.com/10400354/149888998-08c31efa-4525-4318-bc7c-cf01f8408be6.png)
Normal player:
![image](https://user-images.githubusercontent.com/10400354/149889088-60b10449-9315-4be8-b622-983023fc6c8b.png)

