### PR TITLE
Fixed colour issue when spy gets shifted

### DIFF
--- a/source/Patches/CrewmateRoles/SpyMod/PooledMapIconPatch.cs
+++ b/source/Patches/CrewmateRoles/SpyMod/PooledMapIconPatch.cs
@@ -1,0 +1,14 @@
+﻿using HarmonyLib;
+using UnityEngine;
+
+namespace TownOfUs.CrewmateRoles.SpyMod {
+	[HarmonyPatch(typeof(PooledMapIcon), nameof(PooledMapIcon.Reset))]
+	public static class PooledMapIconPatch {
+		public static void Postfix(PooledMapIcon __instance) {
+			var sprite = __instance.GetComponent<SpriteRenderer>();
+			if (sprite != null) {
+				PlayerControl.SetPlayerMaterialColors(new Color(0.8793f, 1, 0, 1), sprite); // Reset Color to default. Fixes Shifted Spy issue
+			}
+		}
+	}
+}


### PR DESCRIPTION
Modified the admin map icons so that they get reset correctly to default colours in Reset function.
Fixes Shifted Spy retaining coloured icons after being shifted