### PR TITLE
Cheap fix for Flash

### DIFF
--- a/source/Patches/Roles/Modifiers/Flash.cs
+++ b/source/Patches/Roles/Modifiers/Flash.cs
@@ -5,7 +5,7 @@ namespace TownOfUs.Roles.Modifiers
 {
     public class Flash : Modifier, IVisualAlteration
     {
-        public static float SpeedFactor = 1.25f;
+        public static float SpeedFactor = 1f;
 
         public Flash(PlayerControl player) : base(player)
         {

--- a/source/VisualAppearance.cs
+++ b/source/VisualAppearance.cs
@@ -4,7 +4,7 @@ namespace TownOfUs
 {
     public class VisualAppearance
     {
-        public float SpeedFactor { get; set; } = 1.0f;
+        public float SpeedFactor { get; set; } = 0.8f;
         public Vector3 SizeFactor { get; set; } = new Vector3(0.7f, 0.7f, 1.0f);
 
     }


### PR DESCRIPTION
Flash now moves at normal (1x) speed
Everyone else moves at 0.8x speed.
Giant is still 0.7x, so not as cumbersome anymore by comparison.
Very cheap workaround. Just up the game movement speed a bit and voila. The Flash lagging is "Fixed".
Just delete this pull request if it's not a useable solution.