### PR TITLE
Option: Phantom knows who they are on game start

### DIFF
--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -166,6 +166,7 @@ namespace TownOfUs
         public static float PoisonCd => Generate.PoisonCooldown.Get();
         public static float PoisonDuration => Generate.PoisonDuration.Get();
         public static bool PoisonerVent => Generate.PoisonerVent.Get();
+        public static bool RevealPhantom => Generate.RevealPhantom.Get();
         public static int LatestSpawn => (int)Generate.LatestSpawn.Get();
         public static float TransportCooldown => Generate.TransportCooldown.Get();
         public static int TransportMaxUses => (int) Generate.TransportMaxUses.Get();

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -169,6 +169,7 @@ namespace TownOfUs.CustomOption
 
         public static CustomHeaderOption Phantom;
         public static CustomNumberOption PhantomTasksRemaining;
+        public static CustomToggleOption RevealPhantom;
 
         public static CustomHeaderOption Snitch;
         public static CustomToggleOption SnitchOnLaunch;
@@ -567,6 +568,7 @@ namespace TownOfUs.CustomOption
                 new CustomHeaderOption(num++, "<color=#662962FF>Phantom</color>");
             PhantomTasksRemaining =
                  new CustomNumberOption(num++, "Tasks Remaining When Phantom Can Be Clicked", 5, 1, 10, 1);
+            RevealPhantom = new CustomToggleOption(num++, "Phantom Knows Who They Are On Game Start", true);
 
             Arsonist = new CustomHeaderOption(num++, "<color=#FF4D00FF>Arsonist</color>");
             DouseCooldown =

--- a/source/Patches/Roles/Role.cs
+++ b/source/Patches/Roles/Role.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Reactor.Extensions;
 using TMPro;
 using TownOfUs.ImpostorRoles.CamouflageMod;
+using TownOfUs.NeutralRoles.PhantomMod;
 using TownOfUs.Roles.Modifiers;
 using UnhollowerBaseLib;
 using UnityEngine;
@@ -201,7 +202,9 @@ namespace TownOfUs.Roles
             if (Player == null) return "";
 
             String PlayerName = Player.GetDefaultOutfit()._playerName;
-
+            if (CustomGameOptions.RevealPhantom && Player == SetPhantom.WillBePhantom) {
+                PlayerName += "<color=#662962FF> P</color>";
+            }
             var modifier = Modifier.GetModifier(Player);
             if (modifier != null && modifier.GetColoredSymbol() != null)
             {


### PR DESCRIPTION
Like the Snitch, this is an option for the Phantom to know who they are on game start.
It adds a purple 'P' next to the player name, like the heart with Lovers.

This should reduce annoyances to some players.
e.g. If you are killed, then the last impostor is voted out so the crewmates win. But then you spawn as Phantom and immediately lose.