### PR TITLE
Fixed bugged bodies after meetings.

### DIFF
--- a/source/Patches/CustomRPC.cs
+++ b/source/Patches/CustomRPC.cs
@@ -116,6 +116,7 @@ namespace TownOfUs
         SyncCustomSettings,
         FixAnimation,
         
-        AddMayorVoteBank
+        AddMayorVoteBank,
+        RemoveAllBodies
     }
 }

--- a/source/Patches/MeetingHud_Start.cs
+++ b/source/Patches/MeetingHud_Start.cs
@@ -1,5 +1,7 @@
 using HarmonyLib;
 using Object = UnityEngine.Object;
+using Hazel;
+using Reactor.Extensions;
 
 namespace TownOfUs
 {
@@ -17,10 +19,12 @@ namespace TownOfUs
     {
         public static void Postfix(MeetingHud __instance)
         {
-            var deadBodies = Object.FindObjectsOfType<DeadBody>();
-            foreach (var body in deadBodies)
-            {
-                Object.Destroy(body.gameObject);
+            var writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,
+                (byte) CustomRPC.RemoveAllBodies, SendOption.Reliable, -1);
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+            var buggedBodies = Object.FindObjectsOfType<DeadBody>();
+            foreach (var body in buggedBodies) {
+                body.gameObject.Destroy();
             }
         }
     }

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -981,6 +981,11 @@ namespace TownOfUs
                     case CustomRPC.AddMayorVoteBank:
                         Role.GetRole<Mayor>(Utils.PlayerById(reader.ReadByte())).VoteBank += reader.ReadInt32();
                         break;
+                    case CustomRPC.RemoveAllBodies:
+                        var buggedBodies = Object.FindObjectsOfType<DeadBody>();
+                        foreach (var body in buggedBodies)
+                            body.gameObject.Destroy();
+                        break;
                 }
             }
         }


### PR DESCRIPTION
Fixed bugged bodies after meetings. They are now removed for everyone, not just the host.
The function now calls `CustomRPC.RemoveAllBodies` to apply the removal across the server, not just the local host.

I 100% recommend testing this. I have confirmed it works locally, by manually calling the function. Though having an actual bugged body was not replicable.