### PR TITLE
Fixed the poison button for Amnesiac when remembering the Poisoner role

### DIFF
--- a/source/Patches/NeutralRoles/Amnesiac Mod/PerformKillButton.cs
+++ b/source/Patches/NeutralRoles/Amnesiac Mod/PerformKillButton.cs
@@ -155,6 +155,7 @@ namespace TownOfUs.NeutralRoles.AmnesiacMod
                     {
                         var poisonerRole = Role.GetRole<Poisoner>(amnesiac);
                         poisonerRole.LastPoisoned = DateTime.UtcNow;
+                        poisonerRole.PoisonButton.enabled = true;
                         DestroyableSingleton<HudManager>.Instance.KillButton.graphic.enabled = false;
                     }
                     else if (PlayerControl.LocalPlayer == other)


### PR DESCRIPTION
If the Amnesiac remembers the Poisoner role, their poison button is now enabled.
Previously, this was not set so it was always disabled.