### PR TITLE
Fix for Kill Button Sprite

### DIFF
--- a/source/Patches/KillButtonSprite.cs
+++ b/source/Patches/KillButtonSprite.cs
@@ -35,6 +35,9 @@ namespace TownOfUs
         {
             if (__instance.KillButton == null) return;
 
+            if (!Kill) Kill = __instance.KillButton.graphic.sprite;
+
+
             var flag = false;
             if (PlayerControl.LocalPlayer.Is(RoleEnum.TimeLord))
             {
@@ -98,13 +101,9 @@ namespace TownOfUs
             }
             else
             {
-                if (!Kill) Kill = __instance.KillButton.graphic.sprite;
-                else
-                {
-                    __instance.KillButton.graphic.sprite = Kill;
-                    __instance.KillButton.buttonLabelText.gameObject.SetActive(true);
-                    __instance.KillButton.buttonLabelText.text = "Kill";
-                }
+                __instance.KillButton.graphic.sprite = Kill;
+                __instance.KillButton.buttonLabelText.gameObject.SetActive(true);
+                __instance.KillButton.buttonLabelText.text = "Kill";
                 flag = PlayerControl.LocalPlayer.Is(RoleEnum.Sheriff);
             }
 


### PR DESCRIPTION
When amnesiac remembers role - or role is changed by other means - to either an imposter, glitch or sheriff the kill button stays as the role they were originally. Then this new sprite persists between rounds.
This fix removes that by moving the if statement to top of the file (KillButtonSprite.cs) and out of the role check
this makes sure that no matter how the code executes - the correct sprite is stored as the kill sprite