### PR TITLE
Added compatibility for LevelImposter mod

### DIFF
--- a/source/Patches/CamoComms.cs
+++ b/source/Patches/CamoComms.cs
@@ -21,6 +21,7 @@ namespace TownOfUs
                         case 3:
                         case 4:
                         case 5:
+                        case 6:
                             var comms1 = ShipStatus.Instance.Systems[SystemTypes.Comms].Cast<HudOverrideSystemType>();
                             if (comms1.IsActive)
                             {

--- a/source/Patches/CrewmateRoles/EngineerMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/EngineerMod/PerformKill.cs
@@ -83,6 +83,16 @@ namespace TownOfUs.CrewmateRoles.EngineerMod
                         }
                     }
                     break;
+                case 6:
+                    var comms6 = ShipStatus.Instance.Systems[SystemTypes.Comms].Cast<HudOverrideSystemType>();
+                    if (comms6.IsActive) return FixComms();
+                    var reactor6 = ShipStatus.Instance.Systems[SystemTypes.Laboratory].Cast<ReactorSystemType>();
+                    if (reactor6.IsActive) return FixReactor(SystemTypes.Laboratory);
+                    var oxygen6 = ShipStatus.Instance.Systems[SystemTypes.LifeSupp].Cast<LifeSuppSystemType>();
+                    if (oxygen6.IsActive) return FixOxygen();
+                    var lights6 = ShipStatus.Instance.Systems[SystemTypes.Electrical].Cast<SwitchSystem>();
+                    if (lights6.IsActive) return FixLights(lights6);
+                    break;
             }
 
             var writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,


### PR DESCRIPTION
Minor changes to improve compatibility w/ LevelImposter (https://github.com/DigiWorm0/LevelImposter)
Most fixes are done by LI, these just add a couple of handles for MapID=6 for engineer fix and camo comms.

*Note: When InnerSloth releases inevitably releases their next map, Submerged will likely move to MapID=6, and LevelImposter will likely move to MapID=7.*