### PR TITLE
Fix lovers dying after meetings

### DIFF
--- a/source/Patches/Roles/Role.cs
+++ b/source/Patches/Roles/Role.cs
@@ -687,6 +687,7 @@ namespace TownOfUs.Roles
                 RoleHistory.Clear();
                 Modifier.ModifierDictionary.Clear();
                 Ability.AbilityDictionary.Clear();
+                Patches.AddHauntPatch.AssassinatedPlayers.Clear();
                 Lights.SetLights(Color.white);
             }
         }

--- a/source/TownOfUs.csproj
+++ b/source/TownOfUs.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.668" />
 		<PackageReference Include="AmongUs.GameLibs.$(GamePlatform)" Version="$(GameVersion)" PrivateAssets="all" />
 		<PackageReference Include="BepInEx.IL2CPP.MSBuild" Version="2.0.1" PrivateAssets="all" />
-		<PackageReference Include="System.Text.Json" Version="5.0.2" PrivateAssets="all" />
+		<PackageReference Include="System.Text.Json" Version="6.0.7" PrivateAssets="all" />
 		<PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-development.866" />
 	</ItemGroup>
 


### PR DESCRIPTION
The assassinated players list is only cleared after a meeting, but that function doesn't get called if the game ends mid-meeting (due to assassinations for instance). This is to clear it on return to the lobby.

The player references in the list are invalid between games but retain a valid PlayerId and can still be "exiled" which runs the lover mod Die function. So when the game ends mid-meeting, the list is retained across games; and after the next meeting, if any of the lovers have a player id in the assassinated players list, it ends up killing the invalid player (nothing happens), the other lover, then the lover.