### PR TITLE
Code Smell Fix: Added a shuffle to the end of SortRoles

### DIFF
--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -109,6 +109,7 @@ namespace TownOfUs
                 }
             }
             while (roles.Count > numRoles) roles.RemoveAt(roles.Count - 1);
+            roles.Shuffle();
         }
 
         private static void SortModifiers(List<(Type, int)> roles, int max)


### PR DESCRIPTION
This code change fixes a code smell in SortRoles. Currently SortRoles returns a list with guaranteed roles filling the lower indices first, followed by the variable roles. This could cause problems with players being assigned exclusively guaranteed roles or variable roles depending on their player index.