### PR TITLE
clarify naming where tuples are used

### DIFF
--- a/source/Patches/CrewmateRoles/DetectiveMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/DetectiveMod/PerformKill.cs
@@ -30,23 +30,23 @@ namespace TownOfUs.CrewmateRoles.DetectiveMod
                     PlayerControl.LocalPlayer.GetTruePosition()) > maxDistance) return false;
                 if (role.ClosestPlayer == null) return false;
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-                if (interact[4] == true)
+                if (interact.abilityUsed)
                 {
                     if (role.ClosestPlayer == role.DetectedKiller) Coroutines.Start(Utils.FlashCoroutine(Color.red));
                     else Coroutines.Start(Utils.FlashCoroutine(Color.green));
                 }
-                if (interact[0] == true)
+                if (interact.fullCooldownReset)
                 {
                     role.LastExamined = DateTime.UtcNow;
                     return false;
                 }
-                else if (interact[1] == true)
+                else if (interact.gaReset)
                 {
                     role.LastExamined = DateTime.UtcNow;
                     role.LastExamined = role.LastExamined.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.ExamineCd);
                     return false;
                 }
-                else if (interact[3] == true) return false;
+                else if (interact.zeroSecReset) return false;
                 return false;
             }
             else

--- a/source/Patches/CrewmateRoles/DetectiveMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/DetectiveMod/PerformKill.cs
@@ -30,23 +30,23 @@ namespace TownOfUs.CrewmateRoles.DetectiveMod
                     PlayerControl.LocalPlayer.GetTruePosition()) > maxDistance) return false;
                 if (role.ClosestPlayer == null) return false;
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-                if (interact.abilityUsed)
+                if (interact.AbilityUsed)
                 {
                     if (role.ClosestPlayer == role.DetectedKiller) Coroutines.Start(Utils.FlashCoroutine(Color.red));
                     else Coroutines.Start(Utils.FlashCoroutine(Color.green));
                 }
-                if (interact.fullCooldownReset)
+                if (interact.FullCooldownReset)
                 {
                     role.LastExamined = DateTime.UtcNow;
                     return false;
                 }
-                else if (interact.gaReset)
+                else if (interact.GaReset)
                 {
                     role.LastExamined = DateTime.UtcNow;
                     role.LastExamined = role.LastExamined.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.ExamineCd);
                     return false;
                 }
-                else if (interact.zeroSecReset) return false;
+                else if (interact.ZeroSecReset) return false;
                 return false;
             }
             else

--- a/source/Patches/CrewmateRoles/MedicMod/Protect.cs
+++ b/source/Patches/CrewmateRoles/MedicMod/Protect.cs
@@ -20,7 +20,7 @@ namespace TownOfUs.CrewmateRoles.MedicMod
             if (role.StartTimer() > 0) return false;
 
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact.abilityUsed)
+            if (interact.AbilityUsed)
             {
                 Utils.Rpc(CustomRPC.Protect, PlayerControl.LocalPlayer.PlayerId, role.ClosestPlayer.PlayerId);
 

--- a/source/Patches/CrewmateRoles/MedicMod/Protect.cs
+++ b/source/Patches/CrewmateRoles/MedicMod/Protect.cs
@@ -20,7 +20,7 @@ namespace TownOfUs.CrewmateRoles.MedicMod
             if (role.StartTimer() > 0) return false;
 
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact[4] == true)
+            if (interact.abilityUsed)
             {
                 Utils.Rpc(CustomRPC.Protect, PlayerControl.LocalPlayer.PlayerId, role.ClosestPlayer.PlayerId);
 

--- a/source/Patches/CrewmateRoles/OracleMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/OracleMod/PerformKill.cs
@@ -26,7 +26,7 @@ namespace TownOfUs.CrewmateRoles.OracleMod
             if (role.ClosestPlayer == null) return false;
 
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact.abilityUsed)
+            if (interact.AbilityUsed)
             {
                 role.Confessor = role.ClosestPlayer;
                 bool showsCorrectFaction = true;
@@ -55,18 +55,18 @@ namespace TownOfUs.CrewmateRoles.OracleMod
                 else role.RevealedFaction = Faction.Impostors;
                 Utils.Rpc(CustomRPC.Confess, PlayerControl.LocalPlayer.PlayerId, role.Confessor.PlayerId, faction);
             }
-            if (interact.fullCooldownReset)
+            if (interact.FullCooldownReset)
             {
                 role.LastConfessed = DateTime.UtcNow;
                 return false;
             }
-            else if (interact.gaReset)
+            else if (interact.GaReset)
             {
                 role.LastConfessed = DateTime.UtcNow;
                 role.LastConfessed = role.LastConfessed.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.ConfessCd);
                 return false;
             }
-            else if (interact.zeroSecReset) return false;
+            else if (interact.ZeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/CrewmateRoles/OracleMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/OracleMod/PerformKill.cs
@@ -26,7 +26,7 @@ namespace TownOfUs.CrewmateRoles.OracleMod
             if (role.ClosestPlayer == null) return false;
 
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact[4] == true)
+            if (interact.abilityUsed)
             {
                 role.Confessor = role.ClosestPlayer;
                 bool showsCorrectFaction = true;
@@ -55,18 +55,18 @@ namespace TownOfUs.CrewmateRoles.OracleMod
                 else role.RevealedFaction = Faction.Impostors;
                 Utils.Rpc(CustomRPC.Confess, PlayerControl.LocalPlayer.PlayerId, role.Confessor.PlayerId, faction);
             }
-            if (interact[0] == true)
+            if (interact.fullCooldownReset)
             {
                 role.LastConfessed = DateTime.UtcNow;
                 return false;
             }
-            else if (interact[1] == true)
+            else if (interact.gaReset)
             {
                 role.LastConfessed = DateTime.UtcNow;
                 role.LastConfessed = role.LastConfessed.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.ConfessCd);
                 return false;
             }
-            else if (interact[3] == true) return false;
+            else if (interact.zeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/CrewmateRoles/SeerMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/SeerMod/PerformKill.cs
@@ -25,22 +25,22 @@ namespace TownOfUs.CrewmateRoles.SeerMod
             if (role.ClosestPlayer == null) return false;
 
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact[4] == true)
+            if (interact.abilityUsed)
             {
                 role.Investigated.Add(role.ClosestPlayer.PlayerId);
             }
-            if (interact[0] == true)
+            if (interact.fullCooldownReset)
             {
                 role.LastInvestigated = DateTime.UtcNow;
                 return false;
             }
-            else if (interact[1] == true)
+            else if (interact.gaReset)
             {
                 role.LastInvestigated = DateTime.UtcNow;
                 role.LastInvestigated = role.LastInvestigated.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.SeerCd);
                 return false;
             }
-            else if (interact[3] == true) return false;
+            else if (interact.zeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/CrewmateRoles/SeerMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/SeerMod/PerformKill.cs
@@ -25,22 +25,22 @@ namespace TownOfUs.CrewmateRoles.SeerMod
             if (role.ClosestPlayer == null) return false;
 
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact.abilityUsed)
+            if (interact.AbilityUsed)
             {
                 role.Investigated.Add(role.ClosestPlayer.PlayerId);
             }
-            if (interact.fullCooldownReset)
+            if (interact.FullCooldownReset)
             {
                 role.LastInvestigated = DateTime.UtcNow;
                 return false;
             }
-            else if (interact.gaReset)
+            else if (interact.GaReset)
             {
                 role.LastInvestigated = DateTime.UtcNow;
                 role.LastInvestigated = role.LastInvestigated.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.SeerCd);
                 return false;
             }
-            else if (interact.zeroSecReset) return false;
+            else if (interact.ZeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/CrewmateRoles/TrackerMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/TrackerMod/PerformKill.cs
@@ -28,7 +28,7 @@ namespace TownOfUs.CrewmateRoles.TrackerMod
             if (!role.ButtonUsable) return false;
 
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact[4] == true)
+            if (interact.abilityUsed)
             {
                 var gameObj = new GameObject();
                 var arrow = gameObj.AddComponent<ArrowBehaviour>();
@@ -53,18 +53,18 @@ namespace TownOfUs.CrewmateRoles.TrackerMod
                 role.TrackerArrows.Add(target.PlayerId, arrow);
                 role.UsesLeft--;
             }
-            if (interact[0] == true)
+            if (interact.fullCooldownReset)
             {
                 role.LastTracked = DateTime.UtcNow;
                 return false;
             }
-            else if (interact[1] == true)
+            else if (interact.gaReset)
             {
                 role.LastTracked = DateTime.UtcNow;
                 role.LastTracked = role.LastTracked.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.TrackCd);
                 return false;
             }
-            else if (interact[3] == true) return false;
+            else if (interact.zeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/CrewmateRoles/TrackerMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/TrackerMod/PerformKill.cs
@@ -28,7 +28,7 @@ namespace TownOfUs.CrewmateRoles.TrackerMod
             if (!role.ButtonUsable) return false;
 
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact.abilityUsed)
+            if (interact.AbilityUsed)
             {
                 var gameObj = new GameObject();
                 var arrow = gameObj.AddComponent<ArrowBehaviour>();
@@ -53,18 +53,18 @@ namespace TownOfUs.CrewmateRoles.TrackerMod
                 role.TrackerArrows.Add(target.PlayerId, arrow);
                 role.UsesLeft--;
             }
-            if (interact.fullCooldownReset)
+            if (interact.FullCooldownReset)
             {
                 role.LastTracked = DateTime.UtcNow;
                 return false;
             }
-            else if (interact.gaReset)
+            else if (interact.GaReset)
             {
                 role.LastTracked = DateTime.UtcNow;
                 role.LastTracked = role.LastTracked.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.TrackCd);
                 return false;
             }
-            else if (interact.zeroSecReset) return false;
+            else if (interact.ZeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/CrewmateRoles/VampireHunterMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/VampireHunterMod/PerformKill.cs
@@ -27,7 +27,7 @@ namespace TownOfUs.CrewmateRoles.VampireHunterMod
             if (!role.ClosestPlayer.Is(RoleEnum.Vampire))
             {
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-                if (interact.fullCooldownReset)
+                if (interact.FullCooldownReset)
                 {
                     role.LastStaked = DateTime.UtcNow;
                     role.UsesLeft--;
@@ -35,31 +35,31 @@ namespace TownOfUs.CrewmateRoles.VampireHunterMod
                         Utils.RpcMurderPlayer(PlayerControl.LocalPlayer, PlayerControl.LocalPlayer);
                     return false;
                 }
-                else if (interact.gaReset)
+                else if (interact.GaReset)
                 {
                     role.LastStaked = DateTime.UtcNow;
                     role.LastStaked = role.LastStaked.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.StakeCd);
                     return false;
                 }
-                else if (interact.zeroSecReset) return false;
+                else if (interact.ZeroSecReset) return false;
                 return false;
             }
             else
             {
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer, true);
-                if (interact.abilityUsed) return false;
-                else if (interact.fullCooldownReset)
+                if (interact.AbilityUsed) return false;
+                else if (interact.FullCooldownReset)
                 {
                     role.LastStaked = DateTime.UtcNow;
                     return false;
                 }
-                else if (interact.gaReset)
+                else if (interact.GaReset)
                 {
                     role.LastStaked = DateTime.UtcNow;
                     role.LastStaked = role.LastStaked.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.StakeCd);
                     return false;
                 }
-                else if (interact.zeroSecReset) return false;
+                else if (interact.ZeroSecReset) return false;
                 return false;
             }
         }

--- a/source/Patches/CrewmateRoles/VampireHunterMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/VampireHunterMod/PerformKill.cs
@@ -27,7 +27,7 @@ namespace TownOfUs.CrewmateRoles.VampireHunterMod
             if (!role.ClosestPlayer.Is(RoleEnum.Vampire))
             {
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-                if (interact[0] == true)
+                if (interact.fullCooldownReset)
                 {
                     role.LastStaked = DateTime.UtcNow;
                     role.UsesLeft--;
@@ -35,31 +35,31 @@ namespace TownOfUs.CrewmateRoles.VampireHunterMod
                         Utils.RpcMurderPlayer(PlayerControl.LocalPlayer, PlayerControl.LocalPlayer);
                     return false;
                 }
-                else if (interact[1] == true)
+                else if (interact.gaReset)
                 {
                     role.LastStaked = DateTime.UtcNow;
                     role.LastStaked = role.LastStaked.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.StakeCd);
                     return false;
                 }
-                else if (interact[3] == true) return false;
+                else if (interact.zeroSecReset) return false;
                 return false;
             }
             else
             {
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer, true);
-                if (interact[4] == true) return false;
-                else if (interact[0] == true)
+                if (interact.abilityUsed) return false;
+                else if (interact.fullCooldownReset)
                 {
                     role.LastStaked = DateTime.UtcNow;
                     return false;
                 }
-                else if (interact[1] == true)
+                else if (interact.gaReset)
                 {
                     role.LastStaked = DateTime.UtcNow;
                     role.LastStaked = role.LastStaked.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.StakeCd);
                     return false;
                 }
-                else if (interact[3] == true) return false;
+                else if (interact.zeroSecReset) return false;
                 return false;
             }
         }

--- a/source/Patches/CultistRoles/WhispererMod/PerformKill.cs
+++ b/source/Patches/CultistRoles/WhispererMod/PerformKill.cs
@@ -30,7 +30,7 @@ namespace TownOfUs.CultistRoles.WhispererMod
                 var closestPlayers = Utils.GetClosestPlayers(truePosition, CustomGameOptions.WhisperRadius, false);
                 if (role.PlayerConversion.Count == 0) role.PlayerConversion = role.GetPlayers();
                 var oldStats = role.PlayerConversion;
-                role.PlayerConversion = [];
+                role.PlayerConversion = new();
                 foreach (var conversionRate in oldStats)
                 {
                     var player = conversionRate.Player;
@@ -51,7 +51,7 @@ namespace TownOfUs.CultistRoles.WhispererMod
 
         public static void CheckConversion(Whisperer role)
         {
-            var removals = new List<Whisperer.ConversionData>();
+            var removals = new List<ConversionData>();
             foreach (var playerConversion in role.PlayerConversion)
             {
                 if (playerConversion.UnconvertableChance <= 0)

--- a/source/Patches/CultistRoles/WhispererMod/TargetColor.cs
+++ b/source/Patches/CultistRoles/WhispererMod/TargetColor.cs
@@ -3,7 +3,6 @@ using TownOfUs.Extensions;
 using TownOfUs.Roles;
 using TownOfUs.Roles.Cultist;
 using UnityEngine;
-using static UnityEngine.ParticleSystem.PlaybackState;
 
 namespace TownOfUs.CultistRoles.WhispererMod
 {
@@ -31,8 +30,8 @@ namespace TownOfUs.CultistRoles.WhispererMod
             {
                 foreach (var state in __instance.playerStates)
                 {
-                    if (stats.Item1.PlayerId != state.TargetPlayerId) continue;
-                    float color = stats.Item2 / 100f;
+                    if (stats.Player.PlayerId != state.TargetPlayerId) continue;
+                    float color = stats.UnconvertableChance / 100f;
                     if (color <= 0) state.NameText.color = Patches.Colors.Impostor;
                     else state.NameText.color = new Color(1f, 1f, color, 1f);
                 }
@@ -61,9 +60,9 @@ namespace TownOfUs.CultistRoles.WhispererMod
 
             foreach (var stats in role.PlayerConversion)
             {
-                float color = stats.Item2/100f;
-                if (color <= 0) stats.Item1.nameText().color = Patches.Colors.Impostor;
-                else stats.Item1.nameText().color = new Color(1f, 1f, color, 1f);
+                float color = stats.UnconvertableChance/100f;
+                if (color <= 0) stats.Player.nameText().color = Patches.Colors.Impostor;
+                else stats.Player.nameText().color = new Color(1f, 1f, color, 1f);
             }
         }
     }

--- a/source/Patches/ImpostorRoles/BlackmailerMod/PerformKill.cs
+++ b/source/Patches/ImpostorRoles/BlackmailerMod/PerformKill.cs
@@ -24,7 +24,7 @@ namespace TownOfUs.ImpostorRoles.BlackmailerMod
                 if (role.BlackmailTimer() != 0) return false;
 
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, target);
-                if (interact.abilityUsed)
+                if (interact.AbilityUsed)
                 {
                     role.Blackmailed?.myRend().material.SetFloat("_Outline", 0f);
                     if (role.Blackmailed != null && role.Blackmailed.Data.IsImpostor())

--- a/source/Patches/ImpostorRoles/BlackmailerMod/PerformKill.cs
+++ b/source/Patches/ImpostorRoles/BlackmailerMod/PerformKill.cs
@@ -24,7 +24,7 @@ namespace TownOfUs.ImpostorRoles.BlackmailerMod
                 if (role.BlackmailTimer() != 0) return false;
 
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, target);
-                if (interact[4] == true)
+                if (interact.abilityUsed)
                 {
                     role.Blackmailed?.myRend().material.SetFloat("_Outline", 0f);
                     if (role.Blackmailed != null && role.Blackmailed.Data.IsImpostor())

--- a/source/Patches/ImpostorRoles/MinerMod/PerformKill.cs
+++ b/source/Patches/ImpostorRoles/MinerMod/PerformKill.cs
@@ -26,7 +26,7 @@ namespace TownOfUs.ImpostorRoles.MinerMod
                 if (!__instance.isActiveAndEnabled) return false;
                 if (!role.CanPlace) return false;
                 if (role.MineTimer() != 0) return false;
-                if (SubmergedCompatibility.GetPlayerElevator(PlayerControl.LocalPlayer).Item1) return false;
+                if (SubmergedCompatibility.GetPlayerElevator(PlayerControl.LocalPlayer).atTopFloor) return false;
                 var position = PlayerControl.LocalPlayer.transform.position;
                 var id = GetAvailableId();
                 Utils.Rpc(CustomRPC.Mine, id, PlayerControl.LocalPlayer.PlayerId, position, position.z + 0.001f);

--- a/source/Patches/ImpostorRoles/MinerMod/PerformKill.cs
+++ b/source/Patches/ImpostorRoles/MinerMod/PerformKill.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Linq;
 using HarmonyLib;
-using Hazel;
 using TownOfUs.Patches;
 using TownOfUs.Roles;
 using UnityEngine;
 using Object = UnityEngine.Object;
-using Reactor.Networking.Extensions;
 
 namespace TownOfUs.ImpostorRoles.MinerMod
 {
@@ -26,7 +24,7 @@ namespace TownOfUs.ImpostorRoles.MinerMod
                 if (!__instance.isActiveAndEnabled) return false;
                 if (!role.CanPlace) return false;
                 if (role.MineTimer() != 0) return false;
-                if (SubmergedCompatibility.GetPlayerElevator(PlayerControl.LocalPlayer).atTopFloor) return false;
+                if (SubmergedCompatibility.GetPlayerElevator(PlayerControl.LocalPlayer).AtTopFloor) return false;
                 var position = PlayerControl.LocalPlayer.transform.position;
                 var id = GetAvailableId();
                 Utils.Rpc(CustomRPC.Mine, id, PlayerControl.LocalPlayer.PlayerId, position, position.z + 0.001f);

--- a/source/Patches/NeutralRoles/ArsonistMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/ArsonistMod/PerformKill.cs
@@ -30,19 +30,19 @@ namespace TownOfUs.NeutralRoles.ArsonistMod
                     if (!role.DousedPlayers.Contains(role.ClosestPlayerIgnite.PlayerId)) return false;
 
                     var interact2 = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayerIgnite);
-                    if (interact2[4] == true) role.Ignite();
-                    if (interact2[0] == true)
+                    if (interact2.abilityUsed) role.Ignite();
+                    if (interact2.fullCooldownReset)
                     {
                         role.LastDoused = DateTime.UtcNow;
                         return false;
                     }
-                    else if (interact2[1] == true)
+                    else if (interact2.gaReset)
                     {
                         role.LastDoused = DateTime.UtcNow;
                         role.LastDoused.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.DouseCd);
                         return false;
                     }
-                    else if (interact2[3] == true) return false;
+                    else if (interact2.zeroSecReset) return false;
                     return false;
                 }
                 else return false;
@@ -57,19 +57,19 @@ namespace TownOfUs.NeutralRoles.ArsonistMod
             if (!flag2) return false;
             if (role.DousedPlayers.Contains(role.ClosestPlayerDouse.PlayerId)) return false;
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayerDouse);
-            if (interact[4] == true) role.DousedPlayers.Add(role.ClosestPlayerDouse.PlayerId);
-            if (interact[0] == true)
+            if (interact.abilityUsed) role.DousedPlayers.Add(role.ClosestPlayerDouse.PlayerId);
+            if (interact.fullCooldownReset)
             {
                 role.LastDoused = DateTime.UtcNow;
                 return false;
             }
-            else if (interact[1] == true)
+            else if (interact.gaReset)
             {
                 role.LastDoused = DateTime.UtcNow;
                 role.LastDoused.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.DouseCd);
                 return false;
             }
-            else if (interact[3] == true) return false;
+            else if (interact.zeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/NeutralRoles/ArsonistMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/ArsonistMod/PerformKill.cs
@@ -30,19 +30,19 @@ namespace TownOfUs.NeutralRoles.ArsonistMod
                     if (!role.DousedPlayers.Contains(role.ClosestPlayerIgnite.PlayerId)) return false;
 
                     var interact2 = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayerIgnite);
-                    if (interact2.abilityUsed) role.Ignite();
-                    if (interact2.fullCooldownReset)
+                    if (interact2.AbilityUsed) role.Ignite();
+                    if (interact2.FullCooldownReset)
                     {
                         role.LastDoused = DateTime.UtcNow;
                         return false;
                     }
-                    else if (interact2.gaReset)
+                    else if (interact2.GaReset)
                     {
                         role.LastDoused = DateTime.UtcNow;
                         role.LastDoused.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.DouseCd);
                         return false;
                     }
-                    else if (interact2.zeroSecReset) return false;
+                    else if (interact2.ZeroSecReset) return false;
                     return false;
                 }
                 else return false;
@@ -57,19 +57,19 @@ namespace TownOfUs.NeutralRoles.ArsonistMod
             if (!flag2) return false;
             if (role.DousedPlayers.Contains(role.ClosestPlayerDouse.PlayerId)) return false;
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayerDouse);
-            if (interact.abilityUsed) role.DousedPlayers.Add(role.ClosestPlayerDouse.PlayerId);
-            if (interact.fullCooldownReset)
+            if (interact.AbilityUsed) role.DousedPlayers.Add(role.ClosestPlayerDouse.PlayerId);
+            if (interact.FullCooldownReset)
             {
                 role.LastDoused = DateTime.UtcNow;
                 return false;
             }
-            else if (interact.gaReset)
+            else if (interact.GaReset)
             {
                 role.LastDoused = DateTime.UtcNow;
                 role.LastDoused.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.DouseCd);
                 return false;
             }
-            else if (interact.zeroSecReset) return false;
+            else if (interact.ZeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/NeutralRoles/DoomsayerMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/DoomsayerMod/PerformKill.cs
@@ -23,22 +23,22 @@ namespace TownOfUs.NeutralRoles.DoomsayerMod
                         GameOptionsData.KillDistances[GameOptionsManager.Instance.currentNormalGameOptions.KillDistance];
             if (!flag3) return false;
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact[4] == true)
+            if (interact.abilityUsed)
             {
                 role.LastObservedPlayer = role.ClosestPlayer;
             }
-            if (interact[0] == true)
+            if (interact.fullCooldownReset)
             {
                 role.LastObserved = DateTime.UtcNow;
                 return false;
             }
-            else if (interact[1] == true)
+            else if (interact.gaReset)
             {
                 role.LastObserved = DateTime.UtcNow;
                 role.LastObserved = role.LastObserved.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.ObserveCooldown);
                 return false;
             }
-            else if (interact[3] == true) return false;
+            else if (interact.zeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/NeutralRoles/DoomsayerMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/DoomsayerMod/PerformKill.cs
@@ -23,22 +23,22 @@ namespace TownOfUs.NeutralRoles.DoomsayerMod
                         GameOptionsData.KillDistances[GameOptionsManager.Instance.currentNormalGameOptions.KillDistance];
             if (!flag3) return false;
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact.abilityUsed)
+            if (interact.AbilityUsed)
             {
                 role.LastObservedPlayer = role.ClosestPlayer;
             }
-            if (interact.fullCooldownReset)
+            if (interact.FullCooldownReset)
             {
                 role.LastObserved = DateTime.UtcNow;
                 return false;
             }
-            else if (interact.gaReset)
+            else if (interact.GaReset)
             {
                 role.LastObserved = DateTime.UtcNow;
                 role.LastObserved = role.LastObserved.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.ObserveCooldown);
                 return false;
             }
-            else if (interact.zeroSecReset) return false;
+            else if (interact.ZeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/NeutralRoles/JuggernautMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/JuggernautMod/PerformKill.cs
@@ -26,25 +26,25 @@ namespace TownOfUs.NeutralRoles.JuggernautMod
                         GameOptionsData.KillDistances[GameOptionsManager.Instance.currentNormalGameOptions.KillDistance];
             if (!flag3) return false;
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer, true);
-            if (interact.abilityUsed) return false;
-            else if (interact.fullCooldownReset)
+            if (interact.AbilityUsed) return false;
+            else if (interact.FullCooldownReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 return false;
             }
-            else if (interact.gaReset)
+            else if (interact.GaReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 role.LastKill = role.LastKill.AddSeconds(-(CustomGameOptions.JuggKCd - CustomGameOptions.ReducedKCdPerKill * role.JuggKills) + CustomGameOptions.ProtectKCReset);
                 return false;
             }
-            else if (interact.survReset)
+            else if (interact.SurvReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 role.LastKill = role.LastKill.AddSeconds(-(CustomGameOptions.JuggKCd - CustomGameOptions.ReducedKCdPerKill * role.JuggKills) + CustomGameOptions.VestKCReset);
                 return false;
             }
-            else if (interact.zeroSecReset) return false;
+            else if (interact.ZeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/NeutralRoles/JuggernautMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/JuggernautMod/PerformKill.cs
@@ -26,25 +26,25 @@ namespace TownOfUs.NeutralRoles.JuggernautMod
                         GameOptionsData.KillDistances[GameOptionsManager.Instance.currentNormalGameOptions.KillDistance];
             if (!flag3) return false;
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer, true);
-            if (interact[4] == true) return false;
-            else if (interact[0] == true)
+            if (interact.abilityUsed) return false;
+            else if (interact.fullCooldownReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 return false;
             }
-            else if (interact[1] == true)
+            else if (interact.gaReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 role.LastKill = role.LastKill.AddSeconds(-(CustomGameOptions.JuggKCd - CustomGameOptions.ReducedKCdPerKill * role.JuggKills) + CustomGameOptions.ProtectKCReset);
                 return false;
             }
-            else if (interact[2] == true)
+            else if (interact.survReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 role.LastKill = role.LastKill.AddSeconds(-(CustomGameOptions.JuggKCd - CustomGameOptions.ReducedKCdPerKill * role.JuggKills) + CustomGameOptions.VestKCReset);
                 return false;
             }
-            else if (interact[3] == true) return false;
+            else if (interact.zeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/NeutralRoles/PestilenceMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/PestilenceMod/PerformKill.cs
@@ -24,25 +24,25 @@ namespace TownOfUs.NeutralRoles.PestilenceMod
                         GameOptionsData.KillDistances[GameOptionsManager.Instance.currentNormalGameOptions.KillDistance];
             if (!flag3) return false;
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer, true);
-            if (interact.abilityUsed) return false;
-            else if (interact.fullCooldownReset)
+            if (interact.AbilityUsed) return false;
+            else if (interact.FullCooldownReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 return false;
             }
-            else if (interact.gaReset)
+            else if (interact.GaReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 role.LastKill = role.LastKill.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.PestKillCd);
                 return false;
             }
-            else if (interact.survReset)
+            else if (interact.SurvReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 role.LastKill = role.LastKill.AddSeconds(CustomGameOptions.VestKCReset - CustomGameOptions.PestKillCd);
                 return false;
             }
-            else if (interact.zeroSecReset) return false;
+            else if (interact.ZeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/NeutralRoles/PestilenceMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/PestilenceMod/PerformKill.cs
@@ -24,25 +24,25 @@ namespace TownOfUs.NeutralRoles.PestilenceMod
                         GameOptionsData.KillDistances[GameOptionsManager.Instance.currentNormalGameOptions.KillDistance];
             if (!flag3) return false;
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer, true);
-            if (interact[4] == true) return false;
-            else if (interact[0] == true)
+            if (interact.abilityUsed) return false;
+            else if (interact.fullCooldownReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 return false;
             }
-            else if (interact[1] == true)
+            else if (interact.gaReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 role.LastKill = role.LastKill.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.PestKillCd);
                 return false;
             }
-            else if (interact[2] == true)
+            else if (interact.survReset)
             {
                 role.LastKill = DateTime.UtcNow;
                 role.LastKill = role.LastKill.AddSeconds(CustomGameOptions.VestKCReset - CustomGameOptions.PestKillCd);
                 return false;
             }
-            else if (interact[3] == true) return false;
+            else if (interact.zeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/NeutralRoles/PlaguebearerMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/PlaguebearerMod/PerformKill.cs
@@ -25,18 +25,18 @@ namespace TownOfUs.NeutralRoles.PlaguebearerMod
                         GameOptionsData.KillDistances[GameOptionsManager.Instance.currentNormalGameOptions.KillDistance];
             if (!flag3) return false;
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact[0] == true)
+            if (interact.fullCooldownReset)
             {
                 role.LastInfected = DateTime.UtcNow;
                 return false;
             }
-            else if (interact[1] == true)
+            else if (interact.gaReset)
             {
                 role.LastInfected = DateTime.UtcNow;
                 role.LastInfected.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.InfectCd);
                 return false;
             }
-            else if (interact[3] == true) return false;
+            else if (interact.zeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/NeutralRoles/PlaguebearerMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/PlaguebearerMod/PerformKill.cs
@@ -25,18 +25,18 @@ namespace TownOfUs.NeutralRoles.PlaguebearerMod
                         GameOptionsData.KillDistances[GameOptionsManager.Instance.currentNormalGameOptions.KillDistance];
             if (!flag3) return false;
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-            if (interact.fullCooldownReset)
+            if (interact.FullCooldownReset)
             {
                 role.LastInfected = DateTime.UtcNow;
                 return false;
             }
-            else if (interact.gaReset)
+            else if (interact.GaReset)
             {
                 role.LastInfected = DateTime.UtcNow;
                 role.LastInfected.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.InfectCd);
                 return false;
             }
-            else if (interact.zeroSecReset) return false;
+            else if (interact.ZeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/NeutralRoles/VampireMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/VampireMod/PerformKill.cs
@@ -50,47 +50,47 @@ namespace TownOfUs.NeutralRoles.VampireMod
                 aliveVamps.Count == 1 && vamps.Count < CustomGameOptions.MaxVampiresPerGame)
             {
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-                if (interact.abilityUsed)
+                if (interact.AbilityUsed)
                 {
                     Convert(role.ClosestPlayer);
                     Utils.Rpc(CustomRPC.Bite, role.ClosestPlayer.PlayerId);
                 }
-                if (interact.fullCooldownReset)
+                if (interact.FullCooldownReset)
                 {
                     role.LastBit = DateTime.UtcNow;
                     return false;
                 }
-                else if (interact.gaReset)
+                else if (interact.GaReset)
                 {
                     role.LastBit = DateTime.UtcNow;
                     role.LastBit = role.LastBit.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.BiteCd);
                     return false;
                 }
-                else if (interact.zeroSecReset) return false;
+                else if (interact.ZeroSecReset) return false;
                 return false;
             }
             else
             {
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer, true);
-                if (interact.abilityUsed) return false;
-                if (interact.fullCooldownReset)
+                if (interact.AbilityUsed) return false;
+                if (interact.FullCooldownReset)
                 {
                     role.LastBit = DateTime.UtcNow;
                     return false;
                 }
-                else if (interact.gaReset)
+                else if (interact.GaReset)
                 {
                     role.LastBit = DateTime.UtcNow;
                     role.LastBit = role.LastBit.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.BiteCd);
                     return false;
                 }
-                else if (interact.survReset)
+                else if (interact.SurvReset)
                 {
                     role.LastBit = DateTime.UtcNow;
                     role.LastBit = role.LastBit.AddSeconds(CustomGameOptions.VestKCReset - CustomGameOptions.BiteCd);
                     return false;
                 }
-                else if (interact.zeroSecReset) return false;
+                else if (interact.ZeroSecReset) return false;
                 return false;
             }
         }

--- a/source/Patches/NeutralRoles/VampireMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/VampireMod/PerformKill.cs
@@ -50,47 +50,47 @@ namespace TownOfUs.NeutralRoles.VampireMod
                 aliveVamps.Count == 1 && vamps.Count < CustomGameOptions.MaxVampiresPerGame)
             {
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
-                if (interact[4] == true)
+                if (interact.abilityUsed)
                 {
                     Convert(role.ClosestPlayer);
                     Utils.Rpc(CustomRPC.Bite, role.ClosestPlayer.PlayerId);
                 }
-                if (interact[0] == true)
+                if (interact.fullCooldownReset)
                 {
                     role.LastBit = DateTime.UtcNow;
                     return false;
                 }
-                else if (interact[1] == true)
+                else if (interact.gaReset)
                 {
                     role.LastBit = DateTime.UtcNow;
                     role.LastBit = role.LastBit.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.BiteCd);
                     return false;
                 }
-                else if (interact[3] == true) return false;
+                else if (interact.zeroSecReset) return false;
                 return false;
             }
             else
             {
                 var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer, true);
-                if (interact[4] == true) return false;
-                if (interact[0] == true)
+                if (interact.abilityUsed) return false;
+                if (interact.fullCooldownReset)
                 {
                     role.LastBit = DateTime.UtcNow;
                     return false;
                 }
-                else if (interact[1] == true)
+                else if (interact.gaReset)
                 {
                     role.LastBit = DateTime.UtcNow;
                     role.LastBit = role.LastBit.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.BiteCd);
                     return false;
                 }
-                else if (interact[2] == true)
+                else if (interact.survReset)
                 {
                     role.LastBit = DateTime.UtcNow;
                     role.LastBit = role.LastBit.AddSeconds(CustomGameOptions.VestKCReset - CustomGameOptions.BiteCd);
                     return false;
                 }
-                else if (interact[3] == true) return false;
+                else if (interact.zeroSecReset) return false;
                 return false;
             }
         }

--- a/source/Patches/NeutralRoles/WerewolfMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/WerewolfMod/PerformKill.cs
@@ -38,25 +38,25 @@ namespace TownOfUs.NeutralRoles.WerewolfMod
             if (!flag3) return false;
 
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer, true);
-            if (interact[4] == true) return false;
-            else if (interact[0] == true)
+            if (interact.abilityUsed) return false;
+            else if (interact.fullCooldownReset)
             {
                 role.LastKilled = DateTime.UtcNow;
                 return false;
             }
-            else if (interact[1] == true)
+            else if (interact.gaReset)
             {
                 role.LastKilled = DateTime.UtcNow;
                 role.LastKilled = role.LastKilled.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.RampageKillCd);
                 return false;
             }
-            else if (interact[2] == true)
+            else if (interact.survReset)
             {
                 role.LastKilled = DateTime.UtcNow;
                 role.LastKilled = role.LastKilled.AddSeconds(CustomGameOptions.VestKCReset - CustomGameOptions.RampageKillCd);
                 return false;
             }
-            else if (interact[3] == true) return false;
+            else if (interact.zeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/NeutralRoles/WerewolfMod/PerformKill.cs
+++ b/source/Patches/NeutralRoles/WerewolfMod/PerformKill.cs
@@ -38,25 +38,25 @@ namespace TownOfUs.NeutralRoles.WerewolfMod
             if (!flag3) return false;
 
             var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer, true);
-            if (interact.abilityUsed) return false;
-            else if (interact.fullCooldownReset)
+            if (interact.AbilityUsed) return false;
+            else if (interact.FullCooldownReset)
             {
                 role.LastKilled = DateTime.UtcNow;
                 return false;
             }
-            else if (interact.gaReset)
+            else if (interact.GaReset)
             {
                 role.LastKilled = DateTime.UtcNow;
                 role.LastKilled = role.LastKilled.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.RampageKillCd);
                 return false;
             }
-            else if (interact.survReset)
+            else if (interact.SurvReset)
             {
                 role.LastKilled = DateTime.UtcNow;
                 role.LastKilled = role.LastKilled.AddSeconds(CustomGameOptions.VestKCReset - CustomGameOptions.RampageKillCd);
                 return false;
             }
-            else if (interact.zeroSecReset) return false;
+            else if (interact.ZeroSecReset) return false;
             return false;
         }
     }

--- a/source/Patches/Roles/Cultist/Whisperer.cs
+++ b/source/Patches/Roles/Cultist/Whisperer.cs
@@ -12,7 +12,6 @@ namespace TownOfUs.Roles.Cultist
         public int ConversionCount;
         public List<ConversionData> PlayerConversion = new();
         public int WhisperConversion;
-        public record ConversionData(PlayerControl Player, int UnconvertableChance);
 
 
         public Whisperer(PlayerControl player) : base(player)

--- a/source/Patches/Roles/Cultist/Whisperer.cs
+++ b/source/Patches/Roles/Cultist/Whisperer.cs
@@ -10,8 +10,9 @@ namespace TownOfUs.Roles.Cultist
         public DateTime LastWhispered;
         public int WhisperCount;
         public int ConversionCount;
-        public List<(PlayerControl, int)> PlayerConversion = new List<(PlayerControl, int)>();
+        public List<ConversionData> PlayerConversion = new();
         public int WhisperConversion;
+        public record ConversionData(PlayerControl Player, int UnconvertableChance);
 
 
         public Whisperer(PlayerControl player) : base(player)
@@ -48,15 +49,15 @@ namespace TownOfUs.Roles.Cultist
             return (num - (float) timeSpan.TotalMilliseconds) / 1000f;
         }
 
-        public List<(PlayerControl, int)> GetPlayers()
+        public List<ConversionData> GetPlayers()
         {
-            var playerList = new List<(PlayerControl, int)>();
+            var playerList = new List<ConversionData>();
             foreach (var player in PlayerControl.AllPlayerControls)
             {
                 if (!(player.Is(RoleEnum.Sheriff) || player.Is(RoleEnum.CultistSeer) |
                     player.Is(RoleEnum.Survivor) || player.Is(RoleEnum.Mayor) || player.Is(RoleEnum.Whisperer)))
                 {
-                    playerList.Add((player, 100));
+                    playerList.Add(new(player, 100));
                 }
             }
             return playerList;

--- a/source/Patches/Roles/Glitch.cs
+++ b/source/Patches/Roles/Glitch.cs
@@ -466,25 +466,25 @@ namespace TownOfUs.Roles
                 {
                     if (__gInstance.Player.inVent) return;
                     var interact = Utils.Interact(__gInstance.Player, __gInstance.KillTarget, true);
-                    if (interact.abilityUsed) return;
-                    else if (interact.fullCooldownReset)
+                    if (interact.AbilityUsed) return;
+                    else if (interact.FullCooldownReset)
                     {
                         __gInstance.LastKill = DateTime.UtcNow;
                         return;
                     }
-                    else if (interact.gaReset)
+                    else if (interact.GaReset)
                     {
                         __gInstance.LastKill = DateTime.UtcNow;
                         __gInstance.LastKill = __gInstance.LastKill.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.GlitchKillCooldown);
                         return;
                     }
-                    else if (interact.survReset)
+                    else if (interact.SurvReset)
                     {
                         __gInstance.LastKill = DateTime.UtcNow;
                         __gInstance.LastKill = __gInstance.LastKill.AddSeconds(CustomGameOptions.VestKCReset - CustomGameOptions.GlitchKillCooldown);
                         return;
                     }
-                    else if (interact.zeroSecReset) return;
+                    else if (interact.ZeroSecReset) return;
                     return;
                 }
             }
@@ -537,22 +537,22 @@ namespace TownOfUs.Roles
                 if (__gInstance.HackTarget != null)
                 {
                     var interact = Utils.Interact(__gInstance.Player, __gInstance.HackTarget);
-                    if (interact.abilityUsed)
+                    if (interact.AbilityUsed)
                     {
                         __gInstance.RpcSetHacked(__gInstance.HackTarget);
                     }
-                    if (interact.fullCooldownReset)
+                    if (interact.FullCooldownReset)
                     {
                         __gInstance.LastHack = DateTime.UtcNow;
                         return;
                     }
-                    else if (interact.gaReset)
+                    else if (interact.GaReset)
                     {
                         __gInstance.LastHack = DateTime.UtcNow;
                         __gInstance.LastHack.AddSeconds(CustomGameOptions.ProtectKCReset  - CustomGameOptions.HackCooldown);
                         return;
                     }
-                    else if (interact.zeroSecReset) return;
+                    else if (interact.ZeroSecReset) return;
                     return;
                 }
             }

--- a/source/Patches/Roles/Glitch.cs
+++ b/source/Patches/Roles/Glitch.cs
@@ -466,25 +466,25 @@ namespace TownOfUs.Roles
                 {
                     if (__gInstance.Player.inVent) return;
                     var interact = Utils.Interact(__gInstance.Player, __gInstance.KillTarget, true);
-                    if (interact[4] == true) return;
-                    else if (interact[0] == true)
+                    if (interact.abilityUsed) return;
+                    else if (interact.fullCooldownReset)
                     {
                         __gInstance.LastKill = DateTime.UtcNow;
                         return;
                     }
-                    else if (interact[1] == true)
+                    else if (interact.gaReset)
                     {
                         __gInstance.LastKill = DateTime.UtcNow;
                         __gInstance.LastKill = __gInstance.LastKill.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.GlitchKillCooldown);
                         return;
                     }
-                    else if (interact[2] == true)
+                    else if (interact.survReset)
                     {
                         __gInstance.LastKill = DateTime.UtcNow;
                         __gInstance.LastKill = __gInstance.LastKill.AddSeconds(CustomGameOptions.VestKCReset - CustomGameOptions.GlitchKillCooldown);
                         return;
                     }
-                    else if (interact[3] == true) return;
+                    else if (interact.zeroSecReset) return;
                     return;
                 }
             }
@@ -537,22 +537,22 @@ namespace TownOfUs.Roles
                 if (__gInstance.HackTarget != null)
                 {
                     var interact = Utils.Interact(__gInstance.Player, __gInstance.HackTarget);
-                    if (interact[4] == true)
+                    if (interact.abilityUsed)
                     {
                         __gInstance.RpcSetHacked(__gInstance.HackTarget);
                     }
-                    if (interact[0] == true)
+                    if (interact.fullCooldownReset)
                     {
                         __gInstance.LastHack = DateTime.UtcNow;
                         return;
                     }
-                    else if (interact[1] == true)
+                    else if (interact.gaReset)
                     {
                         __gInstance.LastHack = DateTime.UtcNow;
                         __gInstance.LastHack.AddSeconds(CustomGameOptions.ProtectKCReset  - CustomGameOptions.HackCooldown);
                         return;
                     }
-                    else if (interact[3] == true) return;
+                    else if (interact.zeroSecReset) return;
                     return;
                 }
             }

--- a/source/Patches/StopImpKill.cs
+++ b/source/Patches/StopImpKill.cs
@@ -23,7 +23,7 @@ namespace TownOfUs
                 return false;
             }
             var interact = Utils.Interact(PlayerControl.LocalPlayer, target, true);
-            if (interact.abilityUsed) return false;
+            if (interact.AbilityUsed) return false;
             if (PlayerControl.LocalPlayer.Is(RoleEnum.Warlock))
             {
                 var warlock = Role.GetRole<Warlock>(PlayerControl.LocalPlayer);
@@ -35,7 +35,7 @@ namespace TownOfUs
                 }
                 PlayerControl.LocalPlayer.SetKillTimer(0.01f);
             }
-            else if (interact.fullCooldownReset)
+            else if (interact.FullCooldownReset)
             {
                 if (PlayerControl.LocalPlayer.Is(ModifierEnum.Underdog))
                 {
@@ -47,17 +47,17 @@ namespace TownOfUs
                 else PlayerControl.LocalPlayer.SetKillTimer(GameOptionsManager.Instance.currentNormalGameOptions.KillCooldown);
                 return false;
             }
-            else if (interact.gaReset)
+            else if (interact.GaReset)
             {
                 PlayerControl.LocalPlayer.SetKillTimer(CustomGameOptions.ProtectKCReset + 0.01f);
                 return false;
             }
-            else if (interact.survReset)
+            else if (interact.SurvReset)
             {
                 PlayerControl.LocalPlayer.SetKillTimer(CustomGameOptions.VestKCReset + 0.01f);
                 return false;
             }
-            else if (interact.zeroSecReset == true)
+            else if (interact.ZeroSecReset == true)
             {
                 PlayerControl.LocalPlayer.SetKillTimer(0.01f);
                 return false;

--- a/source/Patches/StopImpKill.cs
+++ b/source/Patches/StopImpKill.cs
@@ -23,7 +23,7 @@ namespace TownOfUs
                 return false;
             }
             var interact = Utils.Interact(PlayerControl.LocalPlayer, target, true);
-            if (interact[4] == true) return false;
+            if (interact.abilityUsed) return false;
             if (PlayerControl.LocalPlayer.Is(RoleEnum.Warlock))
             {
                 var warlock = Role.GetRole<Warlock>(PlayerControl.LocalPlayer);
@@ -35,7 +35,7 @@ namespace TownOfUs
                 }
                 PlayerControl.LocalPlayer.SetKillTimer(0.01f);
             }
-            else if (interact[0] == true)
+            else if (interact.fullCooldownReset)
             {
                 if (PlayerControl.LocalPlayer.Is(ModifierEnum.Underdog))
                 {
@@ -47,17 +47,17 @@ namespace TownOfUs
                 else PlayerControl.LocalPlayer.SetKillTimer(GameOptionsManager.Instance.currentNormalGameOptions.KillCooldown);
                 return false;
             }
-            else if (interact[1] == true)
+            else if (interact.gaReset)
             {
                 PlayerControl.LocalPlayer.SetKillTimer(CustomGameOptions.ProtectKCReset + 0.01f);
                 return false;
             }
-            else if (interact[2] == true)
+            else if (interact.survReset)
             {
                 PlayerControl.LocalPlayer.SetKillTimer(CustomGameOptions.VestKCReset + 0.01f);
                 return false;
             }
-            else if (interact[3] == true)
+            else if (interact.zeroSecReset == true)
             {
                 PlayerControl.LocalPlayer.SetKillTimer(0.01f);
                 return false;

--- a/source/Patches/SubmergedCompatibility.cs
+++ b/source/Patches/SubmergedCompatibility.cs
@@ -11,7 +11,6 @@ using Il2CppInterop.Runtime.Injection;
 using UnityEngine;
 using Reactor.Utilities;
 using TownOfUs.Roles;
-using ElevatorData = (bool atTopFloor, object player);
 
 namespace TownOfUs.Patches
 {
@@ -174,7 +173,7 @@ namespace TownOfUs.Patches
             Types = AccessTools.GetTypesFromAssembly(Assembly);
 
             InjectedTypes = (Dictionary<string, Type>)AccessTools.PropertyGetter(Types.FirstOrDefault(t => t.Name == "ComponentExtensions"), "RegisteredTypes")
-                .Invoke(null, []);
+                .Invoke(null, Array.Empty<object>());
 
             SubmarineStatusType = Types.First(t => t.Name == "SubmarineStatus");
             SubmergedInstance = AccessTools.Field(SubmarineStatusType, "instance");
@@ -221,8 +220,8 @@ namespace TownOfUs.Patches
             if (!isSubmerged()) return;
 
             ElevatorData elevator = GetPlayerElevator(player);
-            if (!elevator.atTopFloor) return;
-            bool CurrentFloor = (bool)UpperDeckIsTargetFloor.GetValue(getSubElevatorSystem.GetValue(elevator.player)); //true is top, false is bottom
+            if (!elevator.AtTopFloor) return;
+            bool CurrentFloor = (bool)UpperDeckIsTargetFloor.GetValue(getSubElevatorSystem.GetValue(elevator.Player)); //true is top, false is bottom
             bool PlayerFloor = player.transform.position.y > -7f; //true is top, false is bottom
             
             if (CurrentFloor != PlayerFloor)
@@ -235,13 +234,13 @@ namespace TownOfUs.Patches
         {
             if (!isSubmerged()) return;
             ElevatorData elevator = GetPlayerElevator(player);
-            if (!elevator.atTopFloor) return;
+            if (!elevator.AtTopFloor) return;
 
-            int MovementStage = (int)GetMovementStageFromTime.Invoke(elevator.player, null);
+            int MovementStage = (int)GetMovementStageFromTime.Invoke(elevator.Player, null);
             if (MovementStage >= 5)
             {
                 //Fade to clear
-                bool topfloortarget = (bool)UpperDeckIsTargetFloor.GetValue(getSubElevatorSystem.GetValue(elevator.player)); //true is top, false is bottom
+                bool topfloortarget = (bool)UpperDeckIsTargetFloor.GetValue(getSubElevatorSystem.GetValue(elevator.Player)); //true is top, false is bottom
                 bool topintendedtarget = player.transform.position.y > -7f; //true is top, false is bottom
                 if (topfloortarget != topintendedtarget)
                 {

--- a/source/Patches/TupleObjects.cs
+++ b/source/Patches/TupleObjects.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace TownOfUs
+{
+    // records are a nice 1 liner that are ok if values arent modified after creation. 
+    // if modification needed, use class.
+    
+    public record RoleData(Type Role, int Chance, bool Unique);
+
+    
+    public record ModifierData(Type Modifier, int Chance);
+
+
+    public record AbilityData(Type Ability, CustomRPC Rpc, int Chance);
+
+
+    public record ElevatorData(bool AtTopFloor, object Player);
+
+    
+    public class InteractionData
+    {
+        public bool FullCooldownReset { get; set; }
+        
+        public bool GaReset { get; set; }
+        
+        public bool SurvReset { get; set; }
+        
+        public bool ZeroSecReset { get; set; }
+        
+        public bool AbilityUsed { get; set; }
+
+        public InteractionData(bool fullCooldownReset, bool gaReset, bool survReset, bool zeroSecReset, bool abilityUsed)
+        {
+            FullCooldownReset = fullCooldownReset;
+            GaReset = gaReset;
+            SurvReset = survReset;
+            ZeroSecReset = zeroSecReset;
+            AbilityUsed = abilityUsed;
+        }
+    }
+
+
+    public class ConversionData 
+    {
+        public PlayerControl Player { get; set; } 
+        
+        public int UnconvertableChance { get; set; }
+        
+        public ConversionData(PlayerControl player, int unconvertableChance)
+        {
+            Player = player;
+            UnconvertableChance = unconvertableChance;
+        }
+    }
+}

--- a/source/Patches/Utils.cs
+++ b/source/Patches/Utils.cs
@@ -26,7 +26,6 @@ using TownOfUs.CrewmateRoles.ImitatorMod;
 using TownOfUs.CrewmateRoles.AurialMod;
 using Reactor.Networking;
 using Reactor.Networking.Extensions;
-using InteractionData = (bool fullCooldownReset, bool gaReset, bool survReset, bool zeroSecReset, bool abilityUsed);
 
 namespace TownOfUs
 {
@@ -221,7 +220,7 @@ namespace TownOfUs
             }
             if (target == ShowRoundOneShield.FirstRoundShielded && toKill)
             {
-                data.zeroSecReset = true;
+                data.ZeroSecReset = true;
             }
             else if (target.Is(RoleEnum.Pestilence))
             {
@@ -230,28 +229,28 @@ namespace TownOfUs
                     var medic = player.GetMedic().Player.PlayerId;
                     Rpc(CustomRPC.AttemptSound, medic, player.PlayerId);
 
-                    if (CustomGameOptions.ShieldBreaks) data.fullCooldownReset = true;
-                    else data.zeroSecReset = true;
+                    if (CustomGameOptions.ShieldBreaks) data.FullCooldownReset = true;
+                    else data.ZeroSecReset = true;
 
                     StopKill.BreakShield(medic, player.PlayerId, CustomGameOptions.ShieldBreaks);
                 }
-                else if (player.IsProtected()) data.gaReset = true;
+                else if (player.IsProtected()) data.GaReset = true;
                 else RpcMurderPlayer(target, player);
             }
             else if (target.IsOnAlert())
             {
-                if (player.Is(RoleEnum.Pestilence)) data.zeroSecReset = true;
+                if (player.Is(RoleEnum.Pestilence)) data.ZeroSecReset = true;
                 else if (player.IsShielded())
                 {
                     var medic = player.GetMedic().Player.PlayerId;
                     Rpc(CustomRPC.AttemptSound, medic, player.PlayerId);
 
-                    if (CustomGameOptions.ShieldBreaks) data.fullCooldownReset = true;
-                    else data.zeroSecReset = true;
+                    if (CustomGameOptions.ShieldBreaks) data.FullCooldownReset = true;
+                    else data.ZeroSecReset = true;
 
                     StopKill.BreakShield(medic, player.PlayerId, CustomGameOptions.ShieldBreaks);
                 }
-                else if (player.IsProtected()) data.gaReset = true;
+                else if (player.IsProtected()) data.GaReset = true;
                 else RpcMurderPlayer(target, player);
                 if (toKill && CustomGameOptions.KilledOnAlert)
                 {
@@ -260,12 +259,12 @@ namespace TownOfUs
                         var medic = target.GetMedic().Player.PlayerId;
                         Rpc(CustomRPC.AttemptSound, medic, target.PlayerId);
 
-                        if (CustomGameOptions.ShieldBreaks) data.fullCooldownReset = true;
-                        else data.zeroSecReset = true;
+                        if (CustomGameOptions.ShieldBreaks) data.FullCooldownReset = true;
+                        else data.ZeroSecReset = true;
 
                         StopKill.BreakShield(medic, target.PlayerId, CustomGameOptions.ShieldBreaks);
                     }
-                    else if (target.IsProtected()) data.gaReset = true;
+                    else if (target.IsProtected()) data.GaReset = true;
                     else
                     {
                         if (player.Is(RoleEnum.Glitch))
@@ -300,10 +299,10 @@ namespace TownOfUs
                             ww.LastKilled = DateTime.UtcNow;
                         }
                         RpcMurderPlayer(player, target);
-                        data.abilityUsed = true;
-                        data.fullCooldownReset = true;
-                        data.gaReset = false;
-                        data.zeroSecReset = false;
+                        data.AbilityUsed = true;
+                        data.FullCooldownReset = true;
+                        data.GaReset = false;
+                        data.ZeroSecReset = false;
                     }
                 }
             }
@@ -312,17 +311,17 @@ namespace TownOfUs
                 Rpc(CustomRPC.AttemptSound, target.GetMedic().Player.PlayerId, target.PlayerId);
 
                 System.Console.WriteLine(CustomGameOptions.ShieldBreaks + "- shield break");
-                if (CustomGameOptions.ShieldBreaks) data.fullCooldownReset = true;
-                else data.zeroSecReset = true;
+                if (CustomGameOptions.ShieldBreaks) data.FullCooldownReset = true;
+                else data.ZeroSecReset = true;
                 StopKill.BreakShield(target.GetMedic().Player.PlayerId, target.PlayerId, CustomGameOptions.ShieldBreaks);
             }
             else if (target.IsVesting() && toKill)
             {
-                data.survReset = true;
+                data.SurvReset = true;
             }
             else if (target.IsProtected() && toKill)
             {
-                data.gaReset = true;
+                data.GaReset = true;
             }
             else if (toKill)
             {
@@ -358,13 +357,13 @@ namespace TownOfUs
                     ww.LastKilled = DateTime.UtcNow;
                 }
                 RpcMurderPlayer(player, target);
-                data.abilityUsed = true;
-                data.fullCooldownReset = true;
+                data.AbilityUsed = true;
+                data.FullCooldownReset = true;
             }
             else
             {
-                data.abilityUsed = true;
-                data.fullCooldownReset = true;
+                data.AbilityUsed = true;
+                data.FullCooldownReset = true;
             }
 
             return data;


### PR DESCRIPTION
tuples are used for multiple lists in rpchandling, submergedcompatibility, and in whisperer. Utils.interact returns a a list of booleans which can be unclear from  just interact[0] so ive changed to declaring the tuples with named variables rather than item1..etc to be more clear