### PR TITLE
Role Gen Fix

### DIFF
--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -76,7 +76,7 @@ namespace TownOfUs
         private static void SortRoles(this List<(Type, int, bool)> roles, int max)
         {
             var newList = roles.Where(x => x.Item2 == 100).ToList();
-            roles.Shuffle();
+            newList.Shuffle();
 
             if (roles.Count < max)
                 max = roles.Count;
@@ -94,7 +94,10 @@ namespace TownOfUs
             }
 
             while (newList.Count > max)
+            {
+                newList.Shuffle();
                 newList.RemoveAt(newList.Count - 1);
+            }
 
             roles = newList;
             roles.Shuffle();
@@ -103,7 +106,7 @@ namespace TownOfUs
         private static void SortModifiers(this List<(Type, int)> roles, int max)
         {
             var newList = roles.Where(x => x.Item2 == 100).ToList();
-            roles.Shuffle();
+            newList.Shuffle();
 
             if (roles.Count < max)
                 max = roles.Count;
@@ -121,7 +124,10 @@ namespace TownOfUs
             }
 
             while (newList.Count > max)
+            {
+                newList.Shuffle();
                 newList.RemoveAt(newList.Count - 1);
+            }
 
             roles = newList;
             roles.Shuffle();

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -80,6 +80,7 @@ namespace TownOfUs
                 roles.Clear();
                 return;
             }
+
             var chosenRoles = roles.Where(x => x.Item2 == 100).ToList();
             // Shuffle to ensure that the same 100% roles do not appear in
             // every game if there are more than the maximum.
@@ -94,7 +95,7 @@ namespace TownOfUs
                 // Determine which roles appear in this game.
                 var optionalRoles = potentialRoles.Where(x => Check(x.Item2)).ToList();
                 potentialRoles = potentialRoles.Where(x => !optionalRoles.Contains(x)).ToList();
-                
+
                 optionalRoles.Shuffle();
                 chosenRoles.AddRange(optionalRoles.GetRange(0, Math.Min(max - chosenRoles.Count, optionalRoles.Count)));
 
@@ -122,15 +123,7 @@ namespace TownOfUs
 
             var roles2 = roles.Where(x => x.Item2 < 100).ToList();
             roles2.Shuffle();
-
-            foreach (var item in roles2)
-            {
-                if (newList.Count >= max)
-                    break;
-
-                if (Check(item.Item2))
-                    newList.Add(item);
-            }
+            newList.AddRange(roles2.Where(x => Check(x.Item2)));
 
             while (newList.Count > max)
             {
@@ -161,11 +154,8 @@ namespace TownOfUs
                 var killing = PickRoleCount(CustomGameOptions.MinNeutralKillingRoles, Math.Min(CustomGameOptions.MaxNeutralKillingRoles, NeutralKillingRoles.Count));
 
                 var canSubtract = (int faction, int minFaction) => { return faction > minFaction; };
-                List<string> factions = new List<string>()
-                {
-                    "Benign", "Evil", "Killing"
-                };
-                
+                var factions = new List<string>() { "Benign", "Evil", "Killing" };
+
                 // Crew must always start out outnumbering neutrals, so subtract roles until that can be guaranteed.
                 while (Math.Ceiling((double)crewmates.Count/2) <= benign + evil + killing)
                 {

--- a/source/Patches/Shuffle.cs
+++ b/source/Patches/Shuffle.cs
@@ -7,21 +7,24 @@ namespace TownOfUs
     {
         public static void Shuffle<T>(this List<T> list)
         {
+            if (list.Count is 1 or 0)
+                return;
+
             var count = list.Count;
-            var last = count - 1;
-            for (var i = 0; i < last; ++i)
+
+            for (var i = 0; i <= count - 1; ++i)
             {
                 var r = Random.Range(i, count);
-                var tmp = list[i];
-                list[i] = list[r];
-                list[r] = tmp;
+                (list[r], list[i]) = (list[i], list[r]);
             }
         }
 
         public static T TakeFirst<T>(this List<T> list)
         {
+            list.Shuffle();
             var item = list[0];
             list.RemoveAt(0);
+            list.Shuffle();
             return item;
         }
 

--- a/source/Patches/Shuffle.cs
+++ b/source/Patches/Shuffle.cs
@@ -7,19 +7,17 @@ namespace TownOfUs
     {
         public static void Shuffle<T>(this List<T> list)
         {
-            for (var i = list.Count-1; i > 0; --i)
+            for (var i = list.Count - 1; i > 0; --i)
             {
-                var j = Random.Range(0, i+1);
+                var j = Random.Range(0, i + 1);
                 (list[i], list[j]) = (list[j], list[i]);
             }
         }
 
         public static T TakeFirst<T>(this List<T> list)
         {
-            list.Shuffle();
             var item = list[0];
             list.RemoveAt(0);
-            list.Shuffle();
             return item;
         }
 

--- a/source/Patches/Shuffle.cs
+++ b/source/Patches/Shuffle.cs
@@ -16,9 +16,16 @@ namespace TownOfUs
 
         public static T TakeFirst<T>(this List<T> list)
         {
-            var item = list[0];
-            list.RemoveAt(0);
-            return item;
+            try
+            {
+                var item = list[0];
+                list.RemoveAt(0);
+                return item;
+            }
+            catch
+            {
+                return default;
+            }
         }
 
         public static T Ability<T>(this List<T> list)


### PR DESCRIPTION
Addresses #177 and #180

Basically the issue was that the order or the list would mostly be fixed because of the settings staying the same across games. In this pr what it does is basically, it adds the role with 100% first, then randomises the last bit. After which the list is shuffled. For extra insurance, the list is also shuffled when performing TakeFirst so it would be less likely to raise issues