### PR TITLE
hotkey for rejoining previous lobby

### DIFF
--- a/source/Patches/LobbyJoin.cs
+++ b/source/Patches/LobbyJoin.cs
@@ -1,0 +1,52 @@
+using HarmonyLib;
+using InnerNet;
+using UnityEngine;
+
+namespace TownOfUs.Patches
+{
+    [HarmonyPatch]
+
+    public class LobbyJoin
+    {
+        static int GameId;
+
+        static GameObject LobbyText;
+        
+        [HarmonyPatch(typeof(InnerNetClient), nameof(InnerNetClient.JoinGame))]
+        [HarmonyPostfix]
+
+        public static void Postfix(InnerNetClient __instance)
+        {
+            GameId = __instance.GameId;
+        }
+
+        [HarmonyPatch(typeof(MMOnlineManager), nameof(MMOnlineManager.Start))]
+        [HarmonyPostfix]
+
+        public static void Postfix()
+        {
+            LobbyText = new("lobbycode");
+            var comp = LobbyText.AddComponent<TMPro.TextMeshPro>();
+            comp.fontSize = 5;
+            LobbyText.transform.localPosition = new(10.4182f, -3.7f, 0);
+            LobbyText.SetActive(true);
+        }
+
+        [HarmonyPatch(typeof(MMOnlineManager), nameof(MMOnlineManager.Update))]
+        [HarmonyPostfix]
+
+        public static void Postfix(MMOnlineManager __instance)
+        {
+            if (GameId == 0) return;
+            
+            if (Input.GetKeyDown(KeyCode.Tab))
+            {
+                __instance.StartCoroutine_Auto(AmongUsClient.Instance.CoJoinOnlineGameFromCode(GameId));
+            }
+            if (LobbyText && LobbyText.GetComponent<TMPro.TextMeshPro>()) 
+            {
+                LobbyText.GetComponent<TMPro.TextMeshPro>().text = $"Prev Lobby: {GameCode.IntToGameName(GameId)}";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Often times you might disconnect from the lobby. When rejoining you will have to open up the enter code box, copy paste or write the code, and then click enter, and you might have to do this multiple times if you happen to get a error. This pr adds a hotkeythat you can use  to directly try joining the previous lobby that you were either in or attempted to join.