### PR TITLE
check among us version at start to determine compatibility

### DIFF
--- a/source/Patches/Updater.cs
+++ b/source/Patches/Updater.cs
@@ -27,13 +27,13 @@ namespace TownOfUs
             var data = GetJson().FirstOrDefault(x => x.ModVersion.Equals(TownOfUs.VersionString));
             if (data != null)
             {
-                var RequiredVersion = Constants.GetVersion(data.InternalVersion[0], data.InternalVersion[1], data.InternalVersion[2], 0);
+                var RequiredVersions = data.InternalVersions;
                 var AUversion = Constants.GetBroadcastVersion();
-                if (AUversion != RequiredVersion)
+                if (!RequiredVersions.ContainsKey(AUversion))
                 {
-                    string action = AUversion > RequiredVersion ? "downgrade" : "update";
+                    string action = AUversion > RequiredVersions.Keys.Max() ? "downgrade" : "update";
                     string info =
-                        $"ALERT\nTown of Us {TownOfUs.VersionString} requires {data.AUVersion}\nyou have {Application.version}\nPlease {action} your among us version"
+                        $"ALERT\nTown of Us {TownOfUs.VersionString} requires {data.InternalVersions.Values.Last()}\nyou have {Application.version}\nPlease {action} your among us version"
                         + "\nvisit Github or Discord for any help";
                     TwitchManager man = DestroyableSingleton<TwitchManager>.Instance;
                     ModUpdater.InfoPopup = UnityEngine.Object.Instantiate(man.TwitchPopup);
@@ -371,11 +371,9 @@ namespace TownOfUs
 
         public class UpdateData
         {
-            public int[] InternalVersion { get; set; }
+            public Dictionary<int, string> InternalVersions { get; set; }
 
             public string ModVersion { get; set; }
-
-            public string AUVersion { get; set; }
         }
     }
 

--- a/source/Patches/Updater.cs
+++ b/source/Patches/Updater.cs
@@ -10,189 +10,221 @@ using System.Threading.Tasks;
 using System.Text.Json;
 using Twitch;
 using Reactor.Utilities;
-using System.Text.Json.Serialization;
-using Rewired.ComponentControls;
 
-namespace TownOfUs {
+namespace TownOfUs
+{
     [HarmonyPatch(typeof(MainMenuManager), nameof(MainMenuManager.Start))]
-    public class ModUpdaterButton {
+    public class ModUpdaterButton
+    {
         private static Sprite TOUUpdateSprite => TownOfUs.UpdateTOUButton;
         private static Sprite SubmergedUpdateSprite => TownOfUs.UpdateSubmergedButton;
-        private static void Prefix(MainMenuManager __instance) {
+        private static void Prefix(MainMenuManager __instance)
+        {
             //Check if there's a ToU update
             ModUpdater.LaunchUpdater();
-            if (ModUpdater.hasTOUUpdate) {
-                //If there's an update, create and show the update button
-                var template = GameObject.Find("ExitGameButton");
-                if (template != null) {
 
-                    var touButton = UnityEngine.Object.Instantiate(template, null);
-                    touButton.transform.localPosition = new Vector3(touButton.transform.localPosition.x, touButton.transform.localPosition.y + 0.6f, touButton.transform.localPosition.z);
+            var data = GetJson();
+            var RequiredVersion = Constants.GetVersion(data.InternalVersion[0], data.InternalVersion[1], data.InternalVersion[2], 0);
+            var AUversion = Constants.GetBroadcastVersion();
+            if (AUversion != RequiredVersion)
+            {
+                string action = AUversion > RequiredVersion ? "downgrade" : "update";
+                string info =
+                    $"ALERT\nTown of Us requires {data.Version}\nyou have {Application.version}\nPlease {action} your among us version"
+                    + "\nvisit Github or Discord for any help";
+                TwitchManager man = DestroyableSingleton<TwitchManager>.Instance;
+                ModUpdater.InfoPopup = UnityEngine.Object.Instantiate(man.TwitchPopup);
+                ModUpdater.InfoPopup.TextAreaTMP.fontSize *= 0.68f;
+                ModUpdater.InfoPopup.TextAreaTMP.enableAutoSizing = false;
+                ModUpdater.InfoPopup.Show(info);
+                ModUpdater.InfoPopup.StartCoroutine(Effects.Lerp(0.01f, new Action<float>((p) => { ModUpdater.setPopupText(info); })));
+                ModUpdater.InvalidAUVersion = true;
 
-                    touButton.transform.localScale = new Vector3(0.44f, 0.84f, 1f);
-
-                    PassiveButton passiveTOUButton = touButton.GetComponent<PassiveButton>();
-                    SpriteRenderer touButtonSprite = touButton.transform.GetChild(1).GetComponent<SpriteRenderer>();
-                    passiveTOUButton.OnClick = new UnityEngine.UI.Button.ButtonClickedEvent();
-
-                    touButtonSprite.sprite = TOUUpdateSprite;
-                    touButton.transform.GetChild(0).GetComponent<SpriteRenderer>().sprite = TOUUpdateSprite;
-
-                    touButton.transform.SetParent(GameObject.Find("RightPanel").transform);
-                    var pos = touButton.GetComponent<AspectPosition>();
-                    pos.Alignment = AspectPosition.EdgeAlignments.LeftBottom;
-                    pos.DistanceFromEdge = new Vector3(1.5f,1f,0f);
-
-                    //Add onClick event to run the update on button click
-                    passiveTOUButton.OnClick.AddListener((Action) (() =>
-                    {
-                        ModUpdater.ExecuteUpdate("TOU");
-                        touButton.SetActive(false);
-                    }));
-                    
-                    //Set button text
-                    var text = touButton.transform.GetChild(2).GetChild(0).GetComponent<TMPro.TMP_Text>();
-                    __instance.StartCoroutine(Effects.Lerp(0.1f, new System.Action<float>((p) => {
-                        text.SetText("");
-                        pos.AdjustPosition();
-                    })));
-
-                    //Set popup stuff
-                    TwitchManager man = DestroyableSingleton<TwitchManager>.Instance;
-                    ModUpdater.InfoPopup = UnityEngine.Object.Instantiate<GenericPopup>(man.TwitchPopup);
-                    ModUpdater.InfoPopup.TextAreaTMP.fontSize *= 0.7f;
-                    ModUpdater.InfoPopup.TextAreaTMP.enableAutoSizing = false;
-                }
+                return;
             }
-            if (ModUpdater.hasSubmergedUpdate) {
+            if (ModUpdater.HasTOUUpdate)
+            {
                 //If there's an update, create and show the update button
-                var template = GameObject.Find("ExitGameButton");
-                if (template != null) {
-
-                    var submergedButton = UnityEngine.Object.Instantiate(template, null);
-                    submergedButton.transform.localPosition = new Vector3(submergedButton.transform.localPosition.x, submergedButton.transform.localPosition.y + 1.2f, submergedButton.transform.localPosition.z);
-
-                    submergedButton.transform.localScale = new Vector3(0.44f, 0.84f, 1f);
-
-                    PassiveButton passiveSubmergedButton = submergedButton.GetComponent<PassiveButton>();
-                    SpriteRenderer submergedButtonSprite = submergedButton.transform.GetChild(1).GetComponent<SpriteRenderer>();
-                    passiveSubmergedButton.OnClick = new UnityEngine.UI.Button.ButtonClickedEvent();
-
-                    submergedButtonSprite.sprite = SubmergedUpdateSprite;
-                    submergedButton.transform.GetChild(0).GetComponent<SpriteRenderer>().sprite = SubmergedUpdateSprite;
-
-                    submergedButton.transform.SetParent(GameObject.Find("RightPanel").transform);
-                    var pos = submergedButton.GetComponent<AspectPosition>();
-                    pos.Alignment = AspectPosition.EdgeAlignments.LeftBottom;
-                    pos.DistanceFromEdge = new Vector3(1.5f, 1.5f, 0f);
-
-                    //Add onClick event to run the update on button click
-                    passiveSubmergedButton.OnClick.AddListener((Action) (() =>
-                    {
-                        ModUpdater.ExecuteUpdate("Submerged");
-                        submergedButton.SetActive(false);
-                    }));
-                    
-                    //Set button text
-                    var text = submergedButton.transform.GetChild(2).GetChild(0).GetComponent<TMPro.TMP_Text>();
-                    __instance.StartCoroutine(Effects.Lerp(0.1f, new System.Action<float>((p) => {
-                        text.SetText("");
-                        pos.AdjustPosition();
-                    })));
-
-                    //Set popup stuff
-                    TwitchManager man = DestroyableSingleton<TwitchManager>.Instance;
-                    ModUpdater.InfoPopup = UnityEngine.Object.Instantiate<GenericPopup>(man.TwitchPopup);
-                    ModUpdater.InfoPopup.TextAreaTMP.fontSize *= 0.7f;
-                    ModUpdater.InfoPopup.TextAreaTMP.enableAutoSizing = false;
-                }
+                UpdateButton(__instance, () => ModUpdater.ExecuteUpdate("TOU"));
             }
+            if (ModUpdater.HasSubmergedUpdate)
+            {
+                //If there's an update, create and show the update button
+                UpdateButton(__instance, () => ModUpdater.ExecuteUpdate("Submerged"));
+            }
+        }
+
+        private static void UpdateButton(MainMenuManager __instance, Action Onclick)
+        {
+            var template = GameObject.Find("ExitGameButton");
+            if (template != null)
+            {
+
+                var Button = UnityEngine.Object.Instantiate(template, null);
+                Button.transform.localPosition = new Vector3(Button.transform.localPosition.x, Button.transform.localPosition.y + 0.6f, Button.transform.localPosition.z);
+
+                Button.transform.localScale = new Vector3(0.44f, 0.84f, 1f);
+
+                PassiveButton passiveButton = Button.GetComponent<PassiveButton>();
+                SpriteRenderer ButtonSprite = Button.transform.GetChild(1).GetComponent<SpriteRenderer>();
+                passiveButton.OnClick = new UnityEngine.UI.Button.ButtonClickedEvent();
+
+                ButtonSprite.sprite = TOUUpdateSprite;
+                Button.transform.GetChild(0).GetComponent<SpriteRenderer>().sprite = TOUUpdateSprite;
+
+                Button.transform.SetParent(GameObject.Find("RightPanel").transform);
+                var pos = Button.GetComponent<AspectPosition>();
+                pos.Alignment = AspectPosition.EdgeAlignments.LeftBottom;
+                pos.DistanceFromEdge = new Vector3(1.5f, 1f, 0f);
+
+                //Add onClick event to run the update on button click
+                passiveButton.OnClick.AddListener((Action)(() =>
+                {
+                    Onclick();
+                    Button.SetActive(false);
+                }));
+
+                //Set button text
+                var text = Button.transform.GetChild(2).GetChild(0).GetComponent<TMPro.TMP_Text>();
+                __instance.StartCoroutine(Effects.Lerp(0.1f, new Action<float>((p) =>
+                {
+                    text.SetText("");
+                    pos.AdjustPosition();
+                })));
+
+                //Set popup stuff
+                TwitchManager man = DestroyableSingleton<TwitchManager>.Instance;
+                ModUpdater.InfoPopup = UnityEngine.Object.Instantiate(man.TwitchPopup);
+                ModUpdater.InfoPopup.TextAreaTMP.fontSize *= 0.7f;
+                ModUpdater.InfoPopup.TextAreaTMP.enableAutoSizing = false;
+            }
+        }
+
+        private static ModUpdater.AUVersion GetJson()
+        {
+            var text = ModUpdater.Httpclient.GetAsync("https://github.com/eDonnes124/Town-Of-Us-R/raw/master/source/Versioning.json")
+                                 .GetAwaiter().GetResult().Content.ReadAsStringAsync().Result;
+            var data = JsonSerializer.Deserialize<ModUpdater.AUVersion>(text, options: new() { ReadCommentHandling = JsonCommentHandling.Skip });
+            return data;
         }
     }
 
-    public class ModUpdater { 
-        public static bool running = false;
-        public static bool hasTOUUpdate = false;
-        public static bool hasSubmergedUpdate = false;
-        public static string updateTOUURI = null;
-        public static string updateSubmergedURI = null;
-        private static Task updateTOUTask = null;
-        private static Task updateSubmergedTask = null;
+    public class ModUpdater
+    {
+        public static bool Running = false;
+        public static bool HasTOUUpdate = false;
+        public static bool HasSubmergedUpdate = false;
+        public static bool InvalidAUVersion = false;
+        public static string UpdateTOUURI = null;
+        public static string UpdateSubmergedURI = null;
+        private static Task UpdateTOUTask = null;
+        private static Task UpdateSubmergedTask = null;
         public static GenericPopup InfoPopup;
+        public static HttpClient Httpclient = new() 
+        {
+            DefaultRequestHeaders = 
+            {
+                {"User-Agent", "TownOfUs Updater"}
+            } 
+        };
 
-        public static void LaunchUpdater() {
-            if (running) return;
-            running = true;
+        public static void LaunchUpdater()
+        {
+            if (Running) return;
+            Running = true;
 
             checkForUpdate("TOU").GetAwaiter().GetResult();
 
             //Only check of Submerged update if Submerged is already installed
             string codeBase = Assembly.GetExecutingAssembly().Location;
-            System.UriBuilder uri = new System.UriBuilder(codeBase);
-            string submergedPath = System.Uri.UnescapeDataString(uri.Path.Replace("TownOfUs", "Submerged"));
-            if (File.Exists(submergedPath)) {
+            UriBuilder uri = new(codeBase);
+            string submergedPath = Uri.UnescapeDataString(uri.Path.Replace("TownOfUs", "Submerged"));
+            if (File.Exists(submergedPath))
+            {
                 checkForUpdate("Submerged").GetAwaiter().GetResult();
             }
 
             clearOldVersions();
         }
 
-        public static void ExecuteUpdate(string updateType = "TOU") {
+        public static void ExecuteUpdate(string updateType = "TOU")
+        {
             string info = "";
-            if (updateType == "TOU") {
+            if (updateType == "TOU")
+            {
                 info = "Updating Town Of Us\nPlease wait...";
-                ModUpdater.InfoPopup.Show(info);
-                if (updateTOUTask == null) {
-                    if (updateTOUURI != null) {
-                        updateTOUTask = downloadUpdate("TOU");
-                    } else {
+                InfoPopup.Show(info);
+                if (UpdateTOUTask == null)
+                {
+                    if (UpdateTOUURI != null)
+                    {
+                        UpdateTOUTask = downloadUpdate("TOU");
+                    }
+                    else
+                    {
                         info = "Unable to auto-update\nPlease update manually";
                     }
-                } else {
+                }
+                else
+                {
                     info = "Update might already\nbe in progress";
                 }
             }
-            else if (updateType == "Submerged") {
+            else if (updateType == "Submerged")
+            {
                 info = "Updating Submerged\nPlease wait...";
-                ModUpdater.InfoPopup.Show(info);
-                if (updateSubmergedTask == null) {
-                    if (updateSubmergedURI != null) {
-                        updateSubmergedTask = downloadUpdate("Submerged");
-                    } else {
+                InfoPopup.Show(info);
+                if (UpdateSubmergedTask == null)
+                {
+                    if (UpdateSubmergedURI != null)
+                    {
+                        UpdateSubmergedTask = downloadUpdate("Submerged");
+                    }
+                    else
+                    {
                         info = "Unable to auto-update\nPlease update manually";
                     }
-                } else {
+                }
+                else
+                {
                     info = "Update might already\nbe in progress";
                 }
             }
-            ModUpdater.InfoPopup.StartCoroutine(Effects.Lerp(0.01f, new System.Action<float>((p) => { ModUpdater.setPopupText(info); })));
+            InfoPopup.StartCoroutine(Effects.Lerp(0.01f, new System.Action<float>((p) => { ModUpdater.setPopupText(info); })));
         }
-        
-        public static void clearOldVersions() {
+
+        public static void clearOldVersions()
+        {
             //Removes any old versions (Denoted by the suffix `.old`)
-            try {
+            try
+            {
                 DirectoryInfo d = new DirectoryInfo(Path.GetDirectoryName(Application.dataPath) + @"\BepInEx\plugins");
                 string[] files = d.GetFiles("*.old").Select(x => x.FullName).ToArray();
-                foreach (string f in files)
-                    File.Delete(f);
-            } catch (System.Exception e) {
+                foreach (string f in files) File.Delete(f);
+            }
+            catch (Exception e)
+            {
                 PluginSingleton<TownOfUs>.Instance.Log.LogMessage("Exception occured when clearing old versions:\n" + e);
             }
         }
-        public static async Task<bool> checkForUpdate(string updateType = "TOU") {
+        public static async Task<bool> checkForUpdate(string updateType = "TOU")
+        {
             //Checks the github api for Town Of Us tags. Compares current version (from VersionString in TownOfUs.cs) to the latest tag version(on GitHub)
-            try {
+            try
+            {
                 string githubURI = "";
-                if (updateType == "TOU") {
+                if (updateType == "TOU")
+                {
                     githubURI = "https://api.github.com/repos/eDonnes124/Town-Of-Us-R/releases/latest";
-                } else if (updateType == "Submerged") {
+                }
+                else if (updateType == "Submerged")
+                {
                     githubURI = "https://api.github.com/repos/SubmergedAmongUs/Submerged/releases/latest";
                 }
-                HttpClient http = new HttpClient();
-                http.DefaultRequestHeaders.Add("User-Agent", "TownOfUs Updater");
-                var response = await http.GetAsync(new System.Uri(githubURI), HttpCompletionOption.ResponseContentRead);
-                
-                if (response.StatusCode != HttpStatusCode.OK || response.Content == null) {
+                var response = await  Httpclient.GetAsync(new Uri(githubURI), HttpCompletionOption.ResponseContentRead);
+
+                if (response.StatusCode != HttpStatusCode.OK || response.Content == null)
+                {
                     PluginSingleton<TownOfUs>.Instance.Log.LogMessage("Server returned no data: " + response.StatusCode.ToString());
                     return false;
                 }
@@ -200,32 +232,36 @@ namespace TownOfUs {
                 var data = JsonSerializer.Deserialize<GitHubApiObject>(json);
 
                 string tagname = data.tag_name;
-                if (tagname == null) {
+                if (tagname == null)
+                {
                     return false; // Something went wrong
                 }
 
                 int diff = 0;
-                System.Version ver = System.Version.Parse(tagname.Replace("v", ""));
-                if (updateType == "TOU") { //Check TOU version
+                Version ver = Version.Parse(tagname.Replace("v", ""));
+                if (updateType == "TOU")
+                { //Check TOU version
                     diff = TownOfUs.Version.CompareTo(ver);
-                    if (diff < 0) { // TOU update required
-                        hasTOUUpdate = true;
+                    if (diff < 0)
+                    { // TOU update required
+                        HasTOUUpdate = true;
                     }
-                } else if (updateType == "Submerged") {
+                }
+                else if (updateType == "Submerged")
+                {
                     //account for broken version
-                    if (Patches.SubmergedCompatibility.Version == null) hasSubmergedUpdate = true;
+                    if (Patches.SubmergedCompatibility.Version == null) HasSubmergedUpdate = true;
                     else
                     {
                         diff = Patches.SubmergedCompatibility.Version.CompareTo(SemanticVersioning.Version.Parse(tagname.Replace("v", ""))); ;
                         if (diff < 0)
                         { // Submerged update required
-                            hasSubmergedUpdate = true;
+                            HasSubmergedUpdate = true;
                         }
-                    } 
+                    }
                 }
                 var assets = data.assets;
-                if (assets == null)
-                    return false;
+                if (assets == null) return false;
 
                 foreach (var asset in assets)
                 {
@@ -234,44 +270,51 @@ namespace TownOfUs {
                     {
                         if (updateType == "TOU")
                         {
-                            updateTOUURI = asset.browser_download_url;
+                            UpdateTOUURI = asset.browser_download_url;
                         }
                         else if (updateType == "Submerged")
                         {
-                            updateSubmergedURI = asset.browser_download_url;
+                            UpdateSubmergedURI = asset.browser_download_url;
                         }
                         return true;
                     }
                 }
-            } catch (System.Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 PluginSingleton<TownOfUs>.Instance.Log.LogMessage(ex);
             }
             return false;
         }
 
-        public static async Task<bool> downloadUpdate(string updateType = "TOU") {
+        public static async Task<bool> downloadUpdate(string updateType = "TOU")
+        {
             //Downloads the new TownOfUs/Submerged dll from GitHub into the plugins folder
-            string downloadDLL= "";
+            string downloadDLL = "";
             string info = "";
-            if (updateType == "TOU") {
-                downloadDLL = updateTOUURI;
+            if (updateType == "TOU")
+            {
+                downloadDLL = UpdateTOUURI;
                 info = "Town Of Us\nupdated successfully.\nPlease RESTART the game.";
-            } else if (updateType == "Submerged") {
-                downloadDLL = updateSubmergedURI;
+            }
+            else if (updateType == "Submerged")
+            {
+                downloadDLL = UpdateSubmergedURI;
                 info = "Submerged\nupdated successfully.\nPlease RESTART the game.";
             }
-            try {
-                HttpClient http = new HttpClient();
-                http.DefaultRequestHeaders.Add("User-Agent", "TownOfUs Updater");
-                var response = await http.GetAsync(new System.Uri(downloadDLL), HttpCompletionOption.ResponseContentRead);
-                if (response.StatusCode != HttpStatusCode.OK || response.Content == null) {
+            try
+            {
+                var response = await  Httpclient.GetAsync(new System.Uri(downloadDLL), HttpCompletionOption.ResponseContentRead);
+                if (response.StatusCode != HttpStatusCode.OK || response.Content == null)
+                {
                     PluginSingleton<TownOfUs>.Instance.Log.LogMessage("Server returned no data: " + response.StatusCode.ToString());
                     return false;
                 }
                 string codeBase = Assembly.GetExecutingAssembly().Location;
                 System.UriBuilder uri = new System.UriBuilder(codeBase);
                 string fullname = System.Uri.UnescapeDataString(uri.Path);
-                if (updateType == "Submerged") {
+                if (updateType == "Submerged")
+                {
                     fullname = fullname.Replace("TownOfUs", "Submerged"); //TODO A better solution than this to correctly name the dll files
                 }
                 if (File.Exists(fullname + ".old")) // Clear old file in case it wasnt;
@@ -279,28 +322,33 @@ namespace TownOfUs {
 
                 File.Move(fullname, fullname + ".old"); // rename current executable to old
 
-                using (var responseStream = await response.Content.ReadAsStreamAsync()) {
-                    using (var fileStream = File.Create(fullname)) {
-                        responseStream.CopyTo(fileStream);
-                    }
+                using (var responseStream = await response.Content.ReadAsStreamAsync())
+                {
+                    using var fileStream = File.Create(fullname);
+                    responseStream.CopyTo(fileStream);
                 }
                 showPopup(info);
                 return true;
-            } catch (System.Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 PluginSingleton<TownOfUs>.Instance.Log.LogMessage(ex);
             }
             showPopup("Update wasn't successful\nTry again later,\nor update manually.");
             return false;
         }
-        private static void showPopup(string message) {
+        private static void showPopup(string message)
+        {
             setPopupText(message);
             InfoPopup.gameObject.SetActive(true);
         }
 
-        public static void setPopupText(string message) {
-            if (InfoPopup == null)
-                return;
-            if (InfoPopup.TextAreaTMP != null) {
+        public static void setPopupText(string message)
+        {
+            if (InfoPopup == null) return;
+            
+            if (InfoPopup.TextAreaTMP != null)
+            {
                 InfoPopup.TextAreaTMP.text = message;
             }
         }
@@ -308,19 +356,35 @@ namespace TownOfUs {
 
         class GitHubApiObject
         {
-            [JsonPropertyName("tag_name")]
             public string tag_name { get; set; }
-            [JsonPropertyName("assets")]
             public GitHubApiAsset[] assets { get; set; }
         }
 
         class GitHubApiAsset
         {
-            [JsonPropertyName("browser_download_url")]
             public string browser_download_url { get; set; }
         }
 
+        public class AUVersion
+        {
+            public int[] InternalVersion { get; set; }
 
+            public string Version { get; set; }
+        }
     }
 
+    [HarmonyPatch(typeof(GenericPopup), nameof(GenericPopup.Close))]
+    public class TextBoxPatch
+    {
+        [HarmonyPostfix]
+        public static void Postfix(GenericPopup __instance)
+        {
+            if (__instance != ModUpdater.InfoPopup) return;
+
+            if (ModUpdater.InvalidAUVersion)
+            {
+                Application.Quit();
+            }
+        }
+    }
 }

--- a/source/TownOfUs.cs
+++ b/source/TownOfUs.cs
@@ -30,7 +30,7 @@ namespace TownOfUs
     public class TownOfUs : BasePlugin
     {
         public const string Id = "com.slushiegoose.townofus";
-        public const string VersionString = "5.0.2";
+        public const string VersionString = "5.0.2"; //Reminder: update Among us version in Versioning.json
         public static System.Version Version = System.Version.Parse(VersionString);
 
         public static AssetLoader bundledAssets;

--- a/source/Versioning.json
+++ b/source/Versioning.json
@@ -1,8 +1,8 @@
 {
   "InternalVersion": [
     2023, // Constants.Year
-    5, // Constants.Month
-    20 // Constants.Day
+    11, // Constants.Month
+    15 // Constants.Day
   ],
-  "Version": "2023.7.12"
+  "Version": "2023.11.28"
 }

--- a/source/Versioning.json
+++ b/source/Versioning.json
@@ -1,20 +1,14 @@
 [
   {
-    "InternalVersion": [
-      2023, //Constants.Year
-      11, //Constants.Month
-      15 // Constants.Day
-    ],
-    "ModVersion": "5.0.3",
-    "AUVersion": "2023.11.28"
+    "InternalVersions": { // Keep internal versions in order if multiple
+      "50595550": "2023.11.28"
+    },
+    "ModVersion": "5.0.3"
   },
   {
-    "InternalVersion": [
-      2024,
-      2,
-      1
-    ],
-    "ModVersion": "5.0.4",
-    "AUVersion": "2024.3.5"
+    "InternalVersions": {
+      "50603650": "2024.3.5"
+    },
+    "ModVersion": "5.0.4"
   }
 ]

--- a/source/Versioning.json
+++ b/source/Versioning.json
@@ -1,0 +1,8 @@
+{
+  "InternalVersion": [
+    2023, // Constants.Year
+    5, // Constants.Month
+    20 // Constants.Day
+  ],
+  "Version": "2023.7.12"
+}

--- a/source/Versioning.json
+++ b/source/Versioning.json
@@ -1,8 +1,20 @@
-{
-  "InternalVersion": [
-    2023, // Constants.Year
-    11, // Constants.Month
-    15 // Constants.Day
-  ],
-  "Version": "2023.11.28"
-}
+[
+  {
+    "InternalVersion": [
+      2023, //Constants.Year
+      11, //Constants.Month
+      15 // Constants.Day
+    ],
+    "ModVersion": "5.0.3",
+    "AUVersion": "2023.11.28"
+  },
+  {
+    "InternalVersion": [
+      2024,
+      2,
+      1
+    ],
+    "ModVersion": "5.0.4",
+    "AUVersion": "2024.3.5"
+  }
+]

--- a/source/Versioning.json
+++ b/source/Versioning.json
@@ -1,5 +1,5 @@
 [
-  {
+  { // Keys are integers from Constants.GetBroadCastVersion()
     "InternalVersions": { // Keep internal versions in order if multiple
       "50595550": "2023.11.28"
     },


### PR DESCRIPTION
This pr adds another task to be done when the updater comes on.

Now the version of among us that is returned by ```Constants.GetBroadCastVersion``` and  ```GetVersion``` when it is provided the internal version can be compared to check if the mod should allow it. The broadcast version doesnt appear to change between hotfixes while it does for major updates, which are the ones which usually break the mod, so the checking should be reliable for the most part. 

Its probably better to get the user's attention as early as possible rather than later when they try to play. It also stops and alerts before they get the chance to use the ingame updater when it wont work. Ive tried to put the most helpful text that could fit.

the last internal version that is supported is kept stored online in the repo so it can be easily updated

also a small refractor:

-  there was some code that was repeated twice in the MainMenuManager prefix so that has been made into a method so the prefix is shorter length
-  the httpclient was instanatiated twice but its recommended practise to resuse 1 instance
- {} changed to reflect the standard with the rest of the codebase

