### PR TITLE
Minor improvements

### DIFF
--- a/source/Patches/Roles/Role.cs
+++ b/source/Patches/Roles/Role.cs
@@ -475,12 +475,14 @@ namespace TownOfUs.Roles
                         {
                             __instance.__4__this.TeamTitle.text = "Neutral";
                             __instance.__4__this.TeamTitle.color = Color.white;
+                            __instance.__4__this.BackgroundBar.material.color = Color.white;
                         }
                         __instance.__4__this.RoleText.text = role.Name;
                         __instance.__4__this.RoleText.color = role.Color;
+                        __instance.__4__this.YouAreText.color = role.Color;
+                        __instance.__4__this.RoleBlurbText.color = role.Color;
                         __instance.__4__this.RoleBlurbText.text = role.ImpostorText();
                         //    __instance.__4__this.ImpostorText.gameObject.SetActive(true);
-                        __instance.__4__this.BackgroundBar.material.color = role.Color;
                         //                        TestScale = Mathf.Max(__instance.__this.Title.scale, TestScale);
                         //                        __instance.__this.Title.scale = TestScale / role.Scale;
                     }
@@ -522,11 +524,13 @@ namespace TownOfUs.Roles
                         {
                             __instance.__4__this.TeamTitle.text = "Neutral";
                             __instance.__4__this.TeamTitle.color = Color.white;
+                            __instance.__4__this.BackgroundBar.material.color = Color.white;
                         }
                         __instance.__4__this.RoleText.text = role.Name;
                         __instance.__4__this.RoleText.color = role.Color;
+                        __instance.__4__this.YouAreText.color = role.Color;
+                        __instance.__4__this.RoleBlurbText.color = role.Color;
                         __instance.__4__this.RoleBlurbText.text = role.ImpostorText();
-                        __instance.__4__this.BackgroundBar.material.color = role.Color;
                     }
 
                     if (ModifierText != null)
@@ -564,9 +568,12 @@ namespace TownOfUs.Roles
                         {
                             __instance.__4__this.TeamTitle.text = "Neutral";
                             __instance.__4__this.TeamTitle.color = Color.white;
+                            __instance.__4__this.BackgroundBar.material.color = Color.white;
                         }
                         __instance.__4__this.RoleText.text = role.Name;
                         __instance.__4__this.RoleText.color = role.Color;
+                        __instance.__4__this.YouAreText.color = role.Color;
+                        __instance.__4__this.RoleBlurbText.color = role.Color;
                         __instance.__4__this.RoleBlurbText.text = role.ImpostorText();
                         __instance.__4__this.BackgroundBar.material.color = role.Color;
                     }

--- a/source/Patches/Roles/Role.cs
+++ b/source/Patches/Roles/Role.cs
@@ -476,6 +476,7 @@ namespace TownOfUs.Roles
                             __instance.__4__this.TeamTitle.text = "Neutral";
                             __instance.__4__this.TeamTitle.color = Color.white;
                             __instance.__4__this.BackgroundBar.material.color = Color.white;
+                            PlayerControl.LocalPlayer.Data.Role.IntroSound = GetIntroSound(RoleTypes.Shapeshifter);                            
                         }
                         __instance.__4__this.RoleText.text = role.Name;
                         __instance.__4__this.RoleText.color = role.Color;
@@ -525,6 +526,7 @@ namespace TownOfUs.Roles
                             __instance.__4__this.TeamTitle.text = "Neutral";
                             __instance.__4__this.TeamTitle.color = Color.white;
                             __instance.__4__this.BackgroundBar.material.color = Color.white;
+                            PlayerControl.LocalPlayer.Data.Role.IntroSound = GetIntroSound(RoleTypes.Shapeshifter);                            
                         }
                         __instance.__4__this.RoleText.text = role.Name;
                         __instance.__4__this.RoleText.color = role.Color;
@@ -569,6 +571,7 @@ namespace TownOfUs.Roles
                             __instance.__4__this.TeamTitle.text = "Neutral";
                             __instance.__4__this.TeamTitle.color = Color.white;
                             __instance.__4__this.BackgroundBar.material.color = Color.white;
+                            PlayerControl.LocalPlayer.Data.Role.IntroSound = GetIntroSound(RoleTypes.Shapeshifter);                            
                         }
                         __instance.__4__this.RoleText.text = role.Name;
                         __instance.__4__this.RoleText.color = role.Color;
@@ -852,6 +855,34 @@ namespace TownOfUs.Roles
 
                     if (player.Data != null && PlayerControl.LocalPlayer.Data.IsImpostor() && player.Data.IsImpostor()) continue;
                 }
+            }
+        }
+        public static AudioClip GetIntroSound(RoleTypes roleType)
+        {
+            return RoleManager.Instance.AllRoles.Where((role) => role.Role == roleType).FirstOrDefault().IntroSound;
+        }
+    }
+    [HarmonyPatch(typeof(Vent), nameof(Vent.SetOutline))]
+    class SetVentOutlinePatch
+    {
+        public static void Postfix(Vent __instance, [HarmonyArgument(1)] ref bool mainTarget)
+        {
+            var player = PlayerControl.LocalPlayer;
+            var role = Role.GetRole(player);
+            Color color = role.Color;
+            __instance.myRend.material.SetColor("_OutlineColor", color);
+            __instance.myRend.material.SetColor("_AddColor", mainTarget ? color : Color.clear);
+        }
+    }
+    [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.ToggleHighlight))]
+    class ToggleHighlightPatch
+    {
+        public static void Postfix(PlayerControl __instance, [HarmonyArgument(0)] bool active, [HarmonyArgument(1)] RoleTeamTypes team)
+        {
+            var player = PlayerControl.LocalPlayer;
+            var role = Role.GetRole(player);
+            {
+                __instance.cosmetics.currentBodySprite.BodySprite.material.SetColor("_OutlineColor", role.Color);
             }
         }
     }

--- a/source/Patches/Roles/Role.cs
+++ b/source/Patches/Roles/Role.cs
@@ -881,9 +881,7 @@ namespace TownOfUs.Roles
         {
             var player = PlayerControl.LocalPlayer;
             var role = Role.GetRole(player);
-            {
-                __instance.cosmetics.currentBodySprite.BodySprite.material.SetColor("_OutlineColor", role.Color);
-            }
+            __instance.cosmetics.currentBodySprite.BodySprite.material.SetColor("_OutlineColor", role.Color);
         }
     }
 }


### PR DESCRIPTION
I have made minor improvements to certain elements.

- Fully colored role screen
  - The "Your role is" text and the text below the player is now colored with the player's role
- Corrected faction screen
  - The background fade is now colored based on the player's faction rather than the role
- Role colored vent outlines
  - The vent outlines are colored based on the player's role
- Role colored kill button player outlines
  - The outline around players for when a kill button is highlighting a player is now based on the player's role
- Role sound for neutral roles
  - The Shapeshifter role sound from the vanilla game now plays when getting a neutral role

Previews:
![image](https://github.com/eDonnes124/Town-Of-Us-R/assets/51543683/7e5b1135-1044-417d-888c-fbfbd5d8aaed)
![image](https://github.com/eDonnes124/Town-Of-Us-R/assets/51543683/e8797f5b-04cc-4d64-b299-73619ccaf107)
![image](https://github.com/eDonnes124/Town-Of-Us-R/assets/51543683/c1607c04-5dda-4cfe-9580-af9a7160dc5e)
![image](https://github.com/eDonnes124/Town-Of-Us-R/assets/51543683/2d81dc93-a19d-41e2-af13-e65854cdd2e3)
![image](https://github.com/eDonnes124/Town-Of-Us-R/assets/51543683/392b704f-95e4-4b03-ad6f-22810f5c44dd)

_I changed the branch it uses so I can freely edit it without modifying this pull request_