### PR TITLE
Improve Imitator role balance

### DIFF
--- a/source/Patches/CrewmateRoles/ImitatorMod/MeetingStart.cs
+++ b/source/Patches/CrewmateRoles/ImitatorMod/MeetingStart.cs
@@ -27,7 +27,6 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
                 RoleEnum playerRole = Role.GetRole(PlayerControl.LocalPlayer).RoleType;
                 if (PlayerControl.LocalPlayer.Data.IsDead && LimitedUsesRoles.Contains(playerRole) && !StartImitate.UpdatedUses)
                 {
-                    Debug.Log("Sending updated uses");
                     int newUses = 0;
                     if (playerRole == RoleEnum.Engineer)
                     {

--- a/source/Patches/CrewmateRoles/ImitatorMod/MeetingStart.cs
+++ b/source/Patches/CrewmateRoles/ImitatorMod/MeetingStart.cs
@@ -3,6 +3,8 @@ using TownOfUs.Roles;
 using System;
 using System.Linq;
 using TownOfUs.CrewmateRoles.OracleMod;
+using System.Collections.Generic;
+using UnityEngine;
 
 namespace TownOfUs.CrewmateRoles.ImitatorMod
 {
@@ -11,8 +13,52 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
     {
         public static void Postfix(MeetingHud __instance)
         {
+            if (!PlayerControl.LocalPlayer.Is(RoleEnum.Imitator))
+            {
+                // RPC how many uses your ability had left so the Imitator's role knows the accurate count
+                List<RoleEnum> LimitedUsesRoles = new List<RoleEnum>()
+                {
+                    RoleEnum.Engineer,
+                    RoleEnum.Veteran,
+                    RoleEnum.VampireHunter,
+                    RoleEnum.Transporter,
+                    RoleEnum.Trapper
+                };
+                RoleEnum playerRole = Role.GetRole(PlayerControl.LocalPlayer).RoleType;
+                if (PlayerControl.LocalPlayer.Data.IsDead && LimitedUsesRoles.Contains(playerRole) && !StartImitate.UpdatedUses)
+                {
+                    Debug.Log("Sending updated uses");
+                    int newUses = 0;
+                    if (playerRole == RoleEnum.Engineer)
+                    {
+                        newUses = ((Engineer)Role.GetRole(PlayerControl.LocalPlayer)).UsesLeft;
+                    }
+                    else if (playerRole == RoleEnum.Veteran)
+                    {
+                        newUses = ((Veteran)Role.GetRole(PlayerControl.LocalPlayer)).UsesLeft;
+                    }
+                    else if (playerRole == RoleEnum.VampireHunter)
+                    {
+                        newUses = ((VampireHunter)Role.GetRole(PlayerControl.LocalPlayer)).UsesLeft;
+                    }
+                    else if (playerRole == RoleEnum.Transporter)
+                    {
+                        newUses = ((Transporter)Role.GetRole(PlayerControl.LocalPlayer)).UsesLeft;
+                    }
+                    else if (playerRole == RoleEnum.Trapper)
+                    {
+                        newUses = ((Trapper)Role.GetRole(PlayerControl.LocalPlayer)).UsesLeft;
+                    }
+                    foreach(var role in Role.GetRoles(RoleEnum.Imitator))
+                    {
+                        // Only needed once per game
+                        StartImitate.UpdatedUses = true;
+                    }
+                    Utils.Rpc(CustomRPC.UpdateImitator, PlayerControl.LocalPlayer.PlayerId, newUses);
+                }
+                return;
+            }
             if (PlayerControl.LocalPlayer.Data.IsDead) return;
-            if (!PlayerControl.LocalPlayer.Is(RoleEnum.Imitator)) return;
             var imitatorRole = Role.GetRole<Imitator>(PlayerControl.LocalPlayer);
             if (imitatorRole.trappedPlayers != null)
             {

--- a/source/Patches/CrewmateRoles/ImitatorMod/StartImitate.cs
+++ b/source/Patches/CrewmateRoles/ImitatorMod/StartImitate.cs
@@ -4,7 +4,7 @@ using TownOfUs.Roles;
 using UnityEngine;
 using Object = UnityEngine.Object;
 using TownOfUs.Patches;
-using Hazel;
+using System.Collections.Generic;
 
 namespace TownOfUs.CrewmateRoles.ImitatorMod
 {
@@ -18,6 +18,8 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
     public class StartImitate
     {
         public static PlayerControl ImitatingPlayer;
+        public static Dictionary<string, int> LimitedRoleUses;
+        public static bool UpdatedUses = false;
         public static void ExileControllerPostfix(ExileController __instance)
         {
             var exiled = __instance.exiled?.Object;
@@ -46,6 +48,7 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
         {
             if (imitator.ImitatePlayer == null) return;
             ImitatingPlayer = imitator.Player;
+            LimitedRoleUses = imitator.LimitedRoleUses;
             var imitatorRole = Role.GetRole(imitator.ImitatePlayer).RoleType;
             if (imitatorRole == RoleEnum.Haunter)
             {
@@ -63,12 +66,56 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
             if (imitatorRole == RoleEnum.Spy) new Spy(ImitatingPlayer);
             if (imitatorRole == RoleEnum.Tracker) new Tracker(ImitatingPlayer);
             if (imitatorRole == RoleEnum.Sheriff) new Sheriff(ImitatingPlayer);
-            if (imitatorRole == RoleEnum.Veteran) new Veteran(ImitatingPlayer);
+            if (imitatorRole == RoleEnum.Veteran)
+            {
+                var veteran = new Veteran(ImitatingPlayer);
+                if (LimitedRoleUses.ContainsKey("Veteran"))
+                {
+                    veteran.UsesLeft = LimitedRoleUses["Veteran"];
+                }
+                else
+                {
+                    veteran.UsesLeft = ((Veteran)Role.GetRole(imitator.ImitatePlayer)).UsesLeft;
+                }
+            }
             if (imitatorRole == RoleEnum.Altruist) new Altruist(ImitatingPlayer);
-            if (imitatorRole == RoleEnum.Engineer) new Engineer(ImitatingPlayer);
+            if (imitatorRole == RoleEnum.Engineer)
+            {
+                var engi = new Engineer(ImitatingPlayer);
+                if (LimitedRoleUses.ContainsKey("Engineer"))
+                {
+                    engi.UsesLeft = LimitedRoleUses["Engineer"];
+                }
+                else
+                {
+                    engi.UsesLeft = ((Engineer)Role.GetRole(imitator.ImitatePlayer)).UsesLeft;
+                }
+            }
             if (imitatorRole == RoleEnum.Medium) new Medium(ImitatingPlayer);
-            if (imitatorRole == RoleEnum.Transporter) new Transporter(ImitatingPlayer);
-            if (imitatorRole == RoleEnum.Trapper) new Trapper(ImitatingPlayer);
+            if (imitatorRole == RoleEnum.Transporter)
+            {
+                var trans = new Transporter(ImitatingPlayer);
+                if (LimitedRoleUses.ContainsKey("Transporter"))
+                {
+                    trans.UsesLeft = LimitedRoleUses["Transporter"];
+                }
+                else
+                {
+                    trans.UsesLeft = ((Transporter)Role.GetRole(imitator.ImitatePlayer)).UsesLeft;
+                }
+            }
+            if (imitatorRole == RoleEnum.Trapper)
+            {
+                var trapper = new Trapper(ImitatingPlayer);
+                if (LimitedRoleUses.ContainsKey("Trapper"))
+                {
+                    trapper.UsesLeft = LimitedRoleUses["Trapper"];
+                }
+                else
+                {
+                    trapper.UsesLeft = ((Trapper)Role.GetRole(imitator.ImitatePlayer)).UsesLeft;
+                }
+            }
             if (imitatorRole == RoleEnum.Oracle) new Oracle(ImitatingPlayer);
             if (imitatorRole == RoleEnum.Medic)
             {
@@ -79,7 +126,14 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
             if (imitatorRole == RoleEnum.VampireHunter)
             {
                 var vh = new VampireHunter(ImitatingPlayer);
-                vh.UsesLeft = CustomGameOptions.MaxFailedStakesPerGame;
+                if (LimitedRoleUses.ContainsKey("VampireHunter"))
+                {
+                    vh.UsesLeft = LimitedRoleUses["VampireHunter"];
+                }
+                else
+                {
+                    vh.UsesLeft = ((VampireHunter)Role.GetRole(imitator.ImitatePlayer)).UsesLeft;
+                }
                 vh.AddedStakes = true;
             }
             if (imitatorRole == RoleEnum.Aurial)

--- a/source/Patches/CrewmateRoles/ImitatorMod/StopImitate.cs
+++ b/source/Patches/CrewmateRoles/ImitatorMod/StopImitate.cs
@@ -23,6 +23,7 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
             {
                 List<RoleEnum> trappedPlayers = null;
                 PlayerControl confessingPlayer = null;
+                Dictionary<string, int> LimitedRoleUses = StartImitate.LimitedRoleUses;
 
                 if (PlayerControl.LocalPlayer == StartImitate.ImitatingPlayer)
                 {
@@ -31,6 +32,7 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
                     if (PlayerControl.LocalPlayer.Is(RoleEnum.Engineer))
                     {
                         var engineerRole = Role.GetRole<Engineer>(PlayerControl.LocalPlayer);
+                        LimitedRoleUses["Engineer"] = engineerRole.UsesLeft;
                         Object.Destroy(engineerRole.UsesText);
                     }
 
@@ -39,12 +41,14 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
                         var trackerRole = Role.GetRole<Tracker>(PlayerControl.LocalPlayer);
                         trackerRole.TrackerArrows.Values.DestroyAll();
                         trackerRole.TrackerArrows.Clear();
+                        LimitedRoleUses["Trapper"] = trackerRole.UsesLeft;
                         Object.Destroy(trackerRole.UsesText);
                     }
 
                     if (PlayerControl.LocalPlayer.Is(RoleEnum.VampireHunter))
                     {
                         var vhRole = Role.GetRole<VampireHunter>(PlayerControl.LocalPlayer);
+                        LimitedRoleUses["VampireHunter"] = vhRole.UsesLeft;
                         Object.Destroy(vhRole.UsesText);
                     }
 
@@ -58,6 +62,7 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
                     if (PlayerControl.LocalPlayer.Is(RoleEnum.Transporter))
                     {
                         var transporterRole = Role.GetRole<Transporter>(PlayerControl.LocalPlayer);
+                        LimitedRoleUses["Transporter"] = transporterRole.UsesLeft;
                         Object.Destroy(transporterRole.UsesText);
                         if (transporterRole.TransportList != null)
                         {
@@ -72,6 +77,7 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
                     if (PlayerControl.LocalPlayer.Is(RoleEnum.Veteran))
                     {
                         var veteranRole = Role.GetRole<Veteran>(PlayerControl.LocalPlayer);
+                        LimitedRoleUses["Veteran"] = veteranRole.UsesLeft;
                         Object.Destroy(veteranRole.UsesText);
                     }
 
@@ -121,6 +127,7 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
                 var imitator = new Imitator(StartImitate.ImitatingPlayer);
                 imitator.trappedPlayers = trappedPlayers;
                 imitator.confessingPlayer = confessingPlayer;
+                imitator.LimitedRoleUses = LimitedRoleUses;
                 var newRole = Role.GetRole(StartImitate.ImitatingPlayer);
                 newRole.RemoveFromRoleHistory(newRole.RoleType);
                 newRole.Kills = killsList.Kills;

--- a/source/Patches/CrewmateRoles/ImitatorMod/StopImitate.cs
+++ b/source/Patches/CrewmateRoles/ImitatorMod/StopImitate.cs
@@ -41,7 +41,6 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
                         var trackerRole = Role.GetRole<Tracker>(PlayerControl.LocalPlayer);
                         trackerRole.TrackerArrows.Values.DestroyAll();
                         trackerRole.TrackerArrows.Clear();
-                        LimitedRoleUses["Trapper"] = trackerRole.UsesLeft;
                         Object.Destroy(trackerRole.UsesText);
                     }
 
@@ -84,6 +83,7 @@ namespace TownOfUs.CrewmateRoles.ImitatorMod
                     if (PlayerControl.LocalPlayer.Is(RoleEnum.Trapper))
                     {
                         var trapperRole = Role.GetRole<Trapper>(PlayerControl.LocalPlayer);
+                        LimitedRoleUses["Trapper"] = trapperRole.UsesLeft;
                         Object.Destroy(trapperRole.UsesText);
                         trapperRole.traps.ClearTraps();
                         trappedPlayers = trapperRole.trappedPlayers;

--- a/source/Patches/CustomRPC.cs
+++ b/source/Patches/CustomRPC.cs
@@ -72,6 +72,7 @@ namespace TownOfUs
         Bless,
         Camouflage,
         SnitchCultistReveal,
+        UpdateImitator,
 
         BypassKill,
         BypassMultiKill,

--- a/source/Patches/Roles/Imitator.cs
+++ b/source/Patches/Roles/Imitator.cs
@@ -12,6 +12,7 @@ namespace TownOfUs.Roles
 
         public List<RoleEnum> trappedPlayers = null;
         public PlayerControl confessingPlayer = null;
+        public Dictionary<string, int> LimitedRoleUses = new Dictionary<string, int>();
 
 
         public Imitator(PlayerControl player) : base(player)

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -1237,7 +1237,6 @@ namespace TownOfUs
                         {
                             ((Trapper)playerRole).UsesLeft = newUses;
                         }
-                        Debug.Log("Updated " + updatedPlayer.name + " uses to " + newUses);
                         break;
                 }
             }

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -1213,6 +1213,32 @@ namespace TownOfUs
                         GameOptionsManager.Instance.currentNormalGameOptions.RoleOptions.SetRoleRate(RoleTypes.Shapeshifter, 0, 0);
                         if (CustomGameOptions.AutoAdjustSettings) RandomMap.AdjustSettings(readByte);
                         break;
+                    case CustomRPC.UpdateImitator:
+                        var updatedPlayer = Utils.PlayerById(reader.ReadByte());
+                        int newUses = reader.ReadInt32();
+                        var playerRole = Role.GetRole(updatedPlayer);
+                        if (playerRole.RoleType == RoleEnum.Engineer)
+                        {
+                            ((Engineer)playerRole).UsesLeft = newUses;
+                        }
+                        else if (playerRole.RoleType == RoleEnum.Veteran)
+                        {
+                            ((Veteran)playerRole).UsesLeft = newUses;
+                        }
+                        else if (playerRole.RoleType == RoleEnum.VampireHunter)
+                        {
+                            ((VampireHunter)playerRole).UsesLeft = newUses;
+                        }
+                        else if (playerRole.RoleType == RoleEnum.Transporter)
+                        {
+                            ((Transporter)playerRole).UsesLeft = newUses;
+                        }
+                        else if (playerRole.RoleType == RoleEnum.Trapper)
+                        {
+                            ((Trapper)playerRole).UsesLeft = newUses;
+                        }
+                        Debug.Log("Updated " + updatedPlayer.name + " uses to " + newUses);
+                        break;
                 }
             }
         }


### PR DESCRIPTION
Currently, Imitator is an imbalanced role because it ignores the maximum ability uses on certain powerful roles. This PR adjusts the role so that it respects both:
- The ability uses remaining for the dead role when they died (therefore enforcing an *actual* maximum number of uses of that ability per game).
- The ability uses remaining for the imitated role when a meeting is called.

As it stands, Engineer is an unplayable role when in a lobby with Imitator, because if the Imitator grabs their role, their uses of Fix are refreshed every meeting, allowing them to fix basically every sabotage the impostors call instantly for the rest of the game or until they are also killed.

This is clearly not the intention behind giving the Engineer a limited number of fixes, and makes life unfairly miserable for the impostors. This corrects the balance when the roles are combined. If the Engineer used all their fixes before dying, the Imitator gets none. If they had some remaining, the Imitator may use them, but they can only use the amount they had remaining.