### PR TITLE
[Improvement] Vampire Remains Vampire When Remembered

### DIFF
--- a/source/Patches/NeutralRoles/AmnesiacMod/PerformKillButton.cs
+++ b/source/Patches/NeutralRoles/AmnesiacMod/PerformKillButton.cs
@@ -162,8 +162,12 @@ namespace TownOfUs.NeutralRoles.AmnesiacMod
                 }
                 else
                 {
-                    var survivor = new Survivor(other);
-                    survivor.RegenTask();
+                    // If role is not Vampire, turn dead player into Survivor
+                    if (role != RoleEnum.Vampire) var survivor = new Survivor(other); survivor.RegenTask();
+                    // If role is Vampire, keep dead player as Vampire
+                    if (role == RoleEnum.Vampire) var vampire = new Vampire(other); vampire.RegenTask();
+
+
                     if (role == RoleEnum.Arsonist || role == RoleEnum.Glitch || role == RoleEnum.Plaguebearer ||
                             role == RoleEnum.Pestilence || role == RoleEnum.Werewolf || role == RoleEnum.Juggernaut
                              || role == RoleEnum.Vampire)


### PR DESCRIPTION
Vampire is a neutral role that works as a team, much like the Impostors.
When an Impostor is remembered, they stay on their team.
When a Vampire is remembered, they do not. They instead become a Survivor.

This change makes a check for whether the target role is Vampire. If the role is Vampire, it'll keep the Vampire as a Vampire. This was done so Vampires remain as a team even if they get remembered by an Amnesiac.

_Make any changes if necessary_