### PR TITLE
Fix swooper aurial interaction by not swooping swooper for aurial

### DIFF
--- a/source/Patches/Roles/Swooper.cs
+++ b/source/Patches/Roles/Swooper.cs
@@ -54,6 +54,7 @@ namespace TownOfUs.Roles
             {
                 TimeRemaining = 0f;
             }
+            if (PlayerControl.LocalPlayer.Is(RoleEnum.Aurial) && !Role.GetRole<Aurial>(PlayerControl.LocalPlayer).NormalVision) return;
             var color = Color.clear;
             if (PlayerControl.LocalPlayer.Data.IsImpostor() || PlayerControl.LocalPlayer.Data.IsDead) color.a = 0.1f;
 
@@ -79,6 +80,7 @@ namespace TownOfUs.Roles
         {
             Enabled = false;
             LastSwooped = DateTime.UtcNow;
+            if (PlayerControl.LocalPlayer.Is(RoleEnum.Aurial) && !Role.GetRole<Aurial>(PlayerControl.LocalPlayer).NormalVision) return;
             Utils.Unmorph(Player);
             Player.myRend().color = Color.white;
         }


### PR DESCRIPTION
Changes:
- Swooper will not swoop for aurial (when swooper swoops, aurial sees the player as regular aurial color: white or red)
- Swooper's aurial coloring will match other imposters (white -> red)

There is a bug with aurial and swooper currently, which is fixed in this change. Aurial will see a normal-color swooper after an initial swoop. Specifically, the CustomPlayerOutfitType is changed upon swoop (Swooper.Swoop), not changed back on unswoop (because Utils.cs does not unswoop swooper which resets CustomPlayerOutfitType through Swooper.UnSwoop::Utils.Unmorph), which results in aurial coloring not applying correctly (instead of white/red, aurial sees the regular player color).

The change introduced is the same change which prevents normal morph, unmorph, camo for aurial:
https://github.com/eDonnes124/Town-Of-Us-R/blob/master/source/Patches/Utils.cs#L48
https://github.com/eDonnes124/Town-Of-Us-R/blob/master/source/Patches/Utils.cs#L41
https://github.com/eDonnes124/Town-Of-Us-R/blob/master/source/Patches/Utils.cs#L53

By among us lore, aurial can see player "auras" only, not their name and color. It makes sense then for an aurial to see the swooper's "aura" even if they are swooped, as the aura still exists, the player is just invisible. This also makes fixing the bug very easy and consistent across similar usages (aurial does not see color changes: venerer, camo comms, morphs)

Testing:
- tested with regular among us group (probably 100 hours by now), correct aurial behaviour, no apparent bugs