### PR TITLE
Add option for invisible blackmailing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1580,6 +1580,7 @@ This prevents the blackmailed person from speaking during the next meeting.
 |----------|:-------------:|:------:|:------:|
 | Blackmailer | The percentage probability of the Blackmailer appearing | Percentage | 0% |
 | Initial Blackmail Cooldown | The initial cooldown of the Blackmailer's Blackmail button | Time | 10s |
+| Only Target Sees Blackmail | If enabled, only the blackmailed player (and the Blackmailer) will see that the player can't speak. | Toggle | False |
 
 -----------------------
 ## Janitor

--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -261,6 +261,7 @@ namespace TownOfUs
         public static int EvilTargetPercent => (int)Generate.EvilTargetPercent.Get();
         public static float MysticArrowDuration => Generate.MysticArrowDuration.Get();
         public static float BlackmailCd => Generate.BlackmailCooldown.Get();
+        public static bool BlackmailInvisible => Generate.BlackmailInvisible.Get();
         public static float GiantSlow => Generate.GiantSlow.Get();
         public static float FlashSpeed => Generate.FlashSpeed.Get();
         public static float DiseasedMultiplier => Generate.DiseasedKillMultiplier.Get();

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -391,6 +391,7 @@ namespace TownOfUs.CustomOption
 
         public static CustomHeaderOption Blackmailer;
         public static CustomNumberOption BlackmailCooldown;
+        public static CustomToggleOption BlackmailInvisible;
 
         public static CustomHeaderOption Plaguebearer;
         public static CustomNumberOption InfectCooldown;
@@ -1243,6 +1244,8 @@ namespace TownOfUs.CustomOption
             Blackmailer = new CustomHeaderOption(num++, MultiMenu.imposter, "<color=#FF0000FF>Blackmailer</color>");
             BlackmailCooldown =
                 new CustomNumberOption(num++, MultiMenu.imposter, "Initial Blackmail Cooldown", 10f, 1f, 15f, 1f, CooldownFormat);
+            BlackmailInvisible =
+                new CustomToggleOption(num++, MultiMenu.imposter, "Only Target Sees Blackmail", false);
 
             Miner = new CustomHeaderOption(num++, MultiMenu.imposter, "<color=#FF0000FF>Miner</color>");
             MineCooldown =

--- a/source/Patches/ImpostorRoles/BlackmailerMod/BlackmailMeetingUpdate.cs
+++ b/source/Patches/ImpostorRoles/BlackmailerMod/BlackmailMeetingUpdate.cs
@@ -33,7 +33,7 @@ namespace TownOfUs.ImpostorRoles.BlackmailerMod
                     {
                         Coroutines.Start(BlackmailShhh());
                     }
-                    if (role.Blackmailed != null && !role.Blackmailed.Data.IsDead)
+                    if (role.Blackmailed != null && !role.Blackmailed.Data.IsDead && role.CanSeeBlackmailed(PlayerControl.LocalPlayer.PlayerId))
                     {
                         var playerState = __instance.playerStates.FirstOrDefault(x => x.TargetPlayerId == role.Blackmailed.PlayerId);
 
@@ -79,7 +79,7 @@ namespace TownOfUs.ImpostorRoles.BlackmailerMod
 
                 foreach (var role in blackmailers)
                 {
-                    if (role.Blackmailed != null && !role.Blackmailed.Data.IsDead)
+                    if (role.Blackmailed != null && !role.Blackmailed.Data.IsDead && role.CanSeeBlackmailed(PlayerControl.LocalPlayer.PlayerId))
                     {
                         var playerState = __instance.playerStates.FirstOrDefault(x => x.TargetPlayerId == role.Blackmailed.PlayerId);
                         playerState.Overlay.gameObject.SetActive(true);

--- a/source/Patches/Roles/Blackmailer.cs
+++ b/source/Patches/Roles/Blackmailer.cs
@@ -41,5 +41,10 @@ namespace TownOfUs.Roles
             if (flag2) return 0;
             return (num - (float)timeSpan.TotalMilliseconds) / 1000f;
         }
+
+        public bool CanSeeBlackmailed(int playerId)
+        {
+            return !CustomGameOptions.BlackmailInvisible || Blackmailed?.PlayerId == playerId || Player.PlayerId == playerId;
+        }
     }
 }

--- a/source/Patches/Roles/Blackmailer.cs
+++ b/source/Patches/Roles/Blackmailer.cs
@@ -42,9 +42,9 @@ namespace TownOfUs.Roles
             return (num - (float)timeSpan.TotalMilliseconds) / 1000f;
         }
 
-        public bool CanSeeBlackmailed(int playerId)
+        public bool CanSeeBlackmailed(byte playerId)
         {
-            return !CustomGameOptions.BlackmailInvisible || Blackmailed?.PlayerId == playerId || Player.PlayerId == playerId;
+            return !CustomGameOptions.BlackmailInvisible || Blackmailed?.PlayerId == playerId || Player.PlayerId == playerId || Utils.PlayerById(playerId).Data.IsDead;
         }
     }
 }


### PR DESCRIPTION
Currently, Blackmailer is considered a "semi-useless" impostor role and subject to a lot of meta play (or attempted meta play). Using your ability essentially hard-confirms that there is a Blackmailer in play, and the natural inclination of players is to try and circumvent the restriction on speaking to gather information from the blackmailed player, e.g. by asking them to be the only one to vote, or trying to gather info based on vote timing, or encouraging everyone else to skip, following the target after they've been blackmailed to see who interacts with them, buttoning again ASAP to see if they were re-blackmailed, etc. It essentially shines a beacon on a player, making it near-impossible to use to silence someone who actually has info you don't want shared.

Obviously, there is some counterplay to these meta strats, but at their core they run counter to the intention of blackmailing: to stop that person from giving crew any info. Therefore, I've added an option to the settings to make it so that **only** the target (and Blackmailer) can see that they are blackmailed, and any other players will not be able to confirm this.

I think this opens up more interesting dynamics, e.g. the blackmailed target getting voted out because they can't defend themselves, or pretending to be blackmailed to evade suspicion when you are actually not. The heart of ToU's game design often revolves around there being multiple explanations for anything, so not hard-confirming blackmails seems to me to fit better into this design.