### PR TITLE
Hide vanilla roles in hudstring and its tab

### DIFF
--- a/source/Patches/CustomOption/Patches.cs
+++ b/source/Patches/CustomOption/Patches.cs
@@ -206,6 +206,10 @@ namespace TownOfUs.CustomOption
                 {
 
                 }
+
+                var vanillarolebutton = __instance.Tabs.transform.FindChild("RoleTab");
+                __instance.Tabs.transform.FindChild("GameTab").localPosition = new(0.17f, 0, -5);
+                vanillarolebutton.gameObject.SetActive(false);
             }
 
             private static Sprite GetSettingSprite(int index)

--- a/source/Patches/GameSettings.cs
+++ b/source/Patches/GameSettings.cs
@@ -36,8 +36,17 @@ namespace TownOfUs
                 else if (SettingsPage == 3) builder.AppendLine("Impostor Settings");
                 else if (SettingsPage == 4) builder.AppendLine("Modifier Settings");
 
-                if (SettingsPage == -1) builder.Append(new StringBuilder(__result));
-
+                if (SettingsPage == -1)
+                {
+                    var num = RoleManager.Instance.AllRoles.Count(
+                            x => x.Role != RoleTypes.Crewmate && x.Role != RoleTypes.Impostor && x.Role != RoleTypes.CrewmateGhost && x.Role != RoleTypes.ImpostorGhost);
+                    
+                    for (int i = 0;i < num; i++)
+                    {
+                        __result = __result.Remove(__result.LastIndexOf("\n"), 1).Remove(__result.LastIndexOf(":"), 1);
+                    }
+                    builder.Append(new StringBuilder(__result));
+                }
                 else
                 {
                     foreach (var option in CustomOption.CustomOption.AllOptions.Where(x => x.Menu == (MultiMenu)SettingsPage))

--- a/source/Patches/HideVanilla.cs
+++ b/source/Patches/HideVanilla.cs
@@ -1,0 +1,28 @@
+using HarmonyLib;
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
+
+namespace TownOfUs
+{
+    [HarmonyPatch]
+
+    public class HideVanilla
+    {
+        [HarmonyPatch(typeof(TranslationController), nameof(TranslationController.GetString), typeof(StringNames), typeof(Il2CppReferenceArray<Il2CppSystem.Object>))]
+        [HarmonyPrefix]
+        
+        public static bool Prefix(ref string __result, ref StringNames id)
+        {
+            switch (id)
+            {
+                case StringNames.EngineerRole:
+                case StringNames.ScientistRole:
+                case StringNames.GuardianAngelRole:
+                case StringNames.ShapeshifterRole:
+                case StringNames.RoleChanceAndQuantity:
+                    __result = "";
+                    return false;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
people get confused quite alot when the mod mismatches with vanilla and they think their getting 4 roles only. The vanilla roles are also arent used so theres no point showing it.