### PR TITLE
Spy Vitals timing

### DIFF
--- a/source/Patches/CrewmateRoles/SpyMod/Vitals.cs
+++ b/source/Patches/CrewmateRoles/SpyMod/Vitals.cs
@@ -1,0 +1,74 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TownOfUs.CrewmateRoles.MedicMod;
+using UnityEngine;
+
+namespace TownOfUs.Patches.CrewmateRoles.SpyMod
+{
+    [HarmonyPatch]
+    public static class Vitals
+    {
+        private static List<TMPro.TextMeshPro> SpyText = new List<TMPro.TextMeshPro>();
+
+        [HarmonyPatch(typeof(VitalsMinigame), nameof(VitalsMinigame.Begin))]
+        class VitalsMinigameStartPatch
+        {
+            static void Postfix(VitalsMinigame __instance)
+            {
+                if (CustomGameOptions.GameMode == GameMode.Cultist) return;
+
+                if (PlayerControl.LocalPlayer.Is(RoleEnum.Spy))
+                {
+                    SpyText = new List<TMPro.TextMeshPro>();
+                    foreach (VitalsPanel panel in __instance.vitals)
+                    {
+                        TMPro.TextMeshPro text = UnityEngine.Object.Instantiate(__instance.SabText, panel.transform);
+                        SpyText.Add(text);
+                        UnityEngine.Object.DestroyImmediate(text.GetComponent<AlphaBlink>());
+                        text.gameObject.SetActive(false);
+                        text.transform.localScale = Vector3.one * 0.75f;
+                        text.transform.localPosition = new Vector3(-0.75f, -0.23f, 0f);
+
+                    }
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(VitalsMinigame), nameof(VitalsMinigame.Update))]
+        class VitalsMinigameUpdatePatch
+        {
+            static void Postfix(VitalsMinigame __instance)
+            {
+                if (CustomGameOptions.GameMode == GameMode.Cultist) return;
+
+                if (PlayerControl.LocalPlayer.Is(RoleEnum.Spy))
+                {
+                    for (int R = 0; R < __instance.vitals.Length; R++)
+                    {
+                        VitalsPanel vitalsPanel = __instance.vitals[R];
+                        GameData.PlayerInfo player = vitalsPanel.PlayerInfo;
+
+                        if (vitalsPanel.IsDead)
+                        {
+                            DeadPlayer deadPlayer = Murder.KilledPlayers?.Where(x => x.PlayerId == player?.PlayerId)?.FirstOrDefault();
+                            if (deadPlayer != null && R < SpyText.Count && SpyText[R] != null)
+                            {
+                                float Deathtime = ((float)(DateTime.UtcNow - deadPlayer.KillTime).TotalMilliseconds);
+                                SpyText[R].gameObject.SetActive(true);
+                                SpyText[R].text = Math.Round(Deathtime / 1000) + "s";
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (TMPro.TextMeshPro text in SpyText)
+                        if (text != null && text.gameObject != null)
+                            text.gameObject.SetActive(false);
+                }
+            }
+        }
+    }
+}

--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -156,6 +156,7 @@ namespace TownOfUs
         public static bool SnitchSeesImpInMeeting => Generate.SnitchSeesImpInMeeting.Get();
         public static bool SnitchSeesTraitor => Generate.SnitchSeesTraitor.Get();
         public static float MineCd => Generate.MineCooldown.Get();
+        public static bool MinerSpawnOnMira => Generate.MinerSpawnOnMira.Get();
         public static float SwoopCd => Generate.SwoopCooldown.Get();
         public static float SwoopDuration => Generate.SwoopDuration.Get();
         public static bool SwooperVent => Generate.SwooperVent.Get();

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -283,6 +283,7 @@ namespace TownOfUs.CustomOption
 
         public static CustomHeaderOption Miner;
         public static CustomNumberOption MineCooldown;
+        public static CustomToggleOption MinerSpawnOnMira;
 
         public static CustomHeaderOption Swooper;
         public static CustomNumberOption SwoopCooldown;
@@ -1277,6 +1278,8 @@ namespace TownOfUs.CustomOption
             Miner = new CustomHeaderOption(num++, MultiMenu.imposter, "<color=#FF0000FF>Miner</color>");
             MineCooldown =
                 new CustomNumberOption(num++, MultiMenu.imposter, "Mine Cooldown", 25f, 10f, 60f, 2.5f, CooldownFormat);
+            MinerSpawnOnMira =
+                new CustomToggleOption(num++, MultiMenu.imposter, "Can Spawn On Mira HQ", false);
 
             Undertaker = new CustomHeaderOption(num++, MultiMenu.imposter, "<color=#FF0000FF>Undertaker</color>");
             DragCooldown = new CustomNumberOption(num++, MultiMenu.imposter, "Drag Cooldown", 25f, 10f, 60f, 2.5f, CooldownFormat);

--- a/source/Patches/EndGamePatch.cs
+++ b/source/Patches/EndGamePatch.cs
@@ -181,7 +181,7 @@ namespace TownOfUs.Patches {
                     playerRole += " (<color=#" + Patches.Colors.Frosty.ToHtmlStringRGBA() + ">Frosty</color>)";
                 }
                 var player = Role.GetRole(playerControl);
-                if (playerControl.Is(RoleEnum.Phantom) || playerControl.Is(Faction.Crewmates))
+                if (playerControl.Is(RoleEnum.Phantom) || playerControl.Is(Faction.Crewmates) || playerControl.Is(RoleEnum.Survivor) && !playerControl.Data.IsDead)
                 {
                     if ((player.TotalTasks - player.TasksLeft)/player.TotalTasks == 1) playerRole += " | Tasks: <color=#" + Color.green.ToHtmlStringRGBA() + $">{player.TotalTasks - player.TasksLeft}/{player.TotalTasks}</color>";
                     else playerRole += $" | Tasks: {player.TotalTasks - player.TasksLeft}/{player.TotalTasks}";

--- a/source/Patches/Roles/Spy.cs
+++ b/source/Patches/Roles/Spy.cs
@@ -6,7 +6,7 @@ namespace TownOfUs.Roles
         {
             Name = "Spy";
             ImpostorText = () => "Snoop Around And Find Stuff Out";
-            TaskText = () => "Gain extra information on the Admin Table";
+            TaskText = () => "Gain extra information from all devices";
             Color = Patches.Colors.Spy;
             RoleType = RoleEnum.Spy;
             AddToRoleHistory(RoleType);

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -1411,7 +1411,10 @@ namespace TownOfUs
                     if (CustomGameOptions.BlackmailerOn > 0)
                         ImpostorRoles.Add((typeof(Blackmailer), CustomGameOptions.BlackmailerOn, true));
 
-                    if (CustomGameOptions.MinerOn > 0)
+                    if (CustomGameOptions.MinerOn > 0 && CustomGameOptions.MinerSpawnOnMira && GameOptionsManager.Instance?.currentNormalGameOptions?.MapId == 1)
+                        ImpostorRoles.Add((typeof(Miner), CustomGameOptions.MinerOn, true));
+
+                    if (CustomGameOptions.MinerOn > 0 && GameOptionsManager.Instance?.currentNormalGameOptions?.MapId != 1)
                         ImpostorRoles.Add((typeof(Miner), CustomGameOptions.MinerOn, true));
 
                     if (CustomGameOptions.SwooperOn > 0)

--- a/source/Patches/TaskPatches.cs
+++ b/source/Patches/TaskPatches.cs
@@ -19,7 +19,7 @@ namespace TownOfUs
                         (GameOptionsManager.Instance.currentNormalGameOptions.GhostsDoTasks || !playerInfo.IsDead) && !playerInfo.IsImpostor() &&
                         !(
                             playerInfo._object.Is(RoleEnum.Jester) || playerInfo._object.Is(RoleEnum.Amnesiac) ||
-                            playerInfo._object.Is(RoleEnum.Survivor) || playerInfo._object.Is(RoleEnum.GuardianAngel) ||
+                            playerInfo._object.Is(RoleEnum.Survivor) && playerInfo._object.Data.IsDead || playerInfo._object.Is(RoleEnum.GuardianAngel) ||
                             playerInfo._object.Is(RoleEnum.Glitch) || playerInfo._object.Is(RoleEnum.Executioner) ||
                             playerInfo._object.Is(RoleEnum.Arsonist) || playerInfo._object.Is(RoleEnum.Juggernaut) ||
                             playerInfo._object.Is(RoleEnum.Plaguebearer) || playerInfo._object.Is(RoleEnum.Pestilence) ||


### PR DESCRIPTION
This code adds an old feature for spy, the vitals timing, which lets the spy know somebody died, obviously this cannot be used in Cultist Mode.

 ![Spy](https://github.com/eDonnes124/Town-Of-Us-R/assets/140932715/562ea9d6-d594-483a-bab5-9ca09ff5e4a9)