### PR TITLE
remove lag after 1st time opening hats

### DIFF
--- a/source/Patches/CustomHats/CustomHatPatch.cs
+++ b/source/Patches/CustomHats/CustomHatPatch.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using AmongUs.Data;
 using HarmonyLib;
@@ -11,30 +12,48 @@ using Object = UnityEngine.Object;
 namespace TownOfUs.Patches.CustomHats
 {
 
-    [HarmonyPatch(typeof(HatsTab), nameof(HatsTab.OnEnable))]
+    [HarmonyPatch]
+
     public static class HatsTab_OnEnable
     {
+        [HarmonyPatch(typeof(HatsTab), nameof(HatsTab.OnEnable))]
+
         public static bool Prefix(HatsTab __instance)
         {
-            __instance.currentHat = DestroyableSingleton<HatManager>.Instance.GetHatById(DataManager.Player.Customization.Hat);
-            var allHats = DestroyableSingleton<HatManager>.Instance.GetUnlockedHats();
-            var hatGroups = new SortedList<string, List<HatData>>(
-                new PaddedComparer<string>("Vanilla", "")
-            );
-            foreach (var hat in allHats)
+            __instance.currentHat = HatManager.Instance.GetHatById(DataManager.Player.Customization.Hat);
+            var allHats = HatManager.Instance.GetUnlockedHats().ToImmutableList();
+
+            if (HatCache.SortedHats == null)
             {
-                if (!hatGroups.ContainsKey(hat.StoreName))
-                    hatGroups[hat.StoreName] = new List<HatData>();
-                hatGroups[hat.StoreName].Add(hat);
+                HatCache.SortedHats = new(new PaddedComparer<string>("Vanilla", ""));
+                foreach (var hat in allHats)
+                {
+                    if (!HatCache.SortedHats.ContainsKey(hat.StoreName)) HatCache.SortedHats[hat.StoreName] = [];
+                    HatCache.SortedHats[hat.StoreName].Add(hat);
+                }
             }
 
-            foreach (ColorChip instanceColorChip in __instance.ColorChips)
-                instanceColorChip.gameObject.Destroy();
+            if (HatCache.Children.Count > 0)
+            {
+                HatCache.Children.Values.Do(x =>
+                {
+                    x.transform.SetParent(__instance.scroller.Inner);
+                    x.gameObject.SetActive(true);
+                });
+                __instance.scroller.ContentYBounds.max = -(__instance.YStart - (HatCache.hatIdx + 1) / __instance.NumPerRow * __instance.YOffset) - 3f;
+                __instance.currentHatIsEquipped = true;
+
+                return false;
+            }
+
+            foreach (ColorChip instanceColorChip in __instance.ColorChips) instanceColorChip.gameObject.Destroy();
             __instance.ColorChips.Clear();
+
             var groupNameText = __instance.GetComponentInChildren<TextMeshPro>(false);
             int hatIdx = 0;
-            foreach ((string groupName, List<HatData> hats) in hatGroups)
+            foreach ((string groupName, List<HatData> hats) in HatCache.SortedHats)
             {
+                hatIdx = (hatIdx + 4) / 5 * 5;
                 var text = Object.Instantiate(groupNameText, __instance.scroller.Inner);
                 text.gameObject.transform.localScale = Vector3.one;
                 text.GetComponent<TextTranslatorTMP>().Destroy();
@@ -43,36 +62,60 @@ namespace TownOfUs.Patches.CustomHats
                 text.fontSize = 3f;
                 text.fontSizeMax = 3f;
                 text.fontSizeMin = 0f;
-
-                hatIdx = (hatIdx + 4) / 5 * 5;
-
+                text.name = $"{groupName} header";
                 float xLerp = __instance.XRange.Lerp(0.5f);
-                float yLerp = __instance.YStart - (hatIdx / __instance.NumPerRow) * __instance.YOffset;
+                float yLerp = __instance.YStart - hatIdx / __instance.NumPerRow * __instance.YOffset;
                 text.transform.localPosition = new Vector3(xLerp, yLerp, -1f);
+                HatCache.Children.Add(groupName, text.transform);
+
                 hatIdx += 5;
                 foreach (var hat in hats.OrderBy(HatManager.Instance.allHats.IndexOf))
                 {
                     float num = __instance.XRange.Lerp(hatIdx % __instance.NumPerRow / (__instance.NumPerRow - 1f));
                     float num2 = __instance.YStart - hatIdx / __instance.NumPerRow * __instance.YOffset;
-                    ColorChip colorChip = Object.Instantiate(__instance.ColorTabPrefab, __instance.scroller.Inner);
-                    colorChip.transform.localPosition = new Vector3(num, num2, -1f);
+
+                    var colorChip = Object.Instantiate(__instance.ColorTabPrefab, __instance.scroller.Inner);
+                    colorChip.gameObject.name = hat.ProductId;
                     colorChip.Button.OnClick.AddListener((Action)(() => __instance.SelectHat(hat)));
-                    colorChip.Inner.SetHat(hat, __instance.HasLocalPlayer() ? PlayerControl.LocalPlayer.Data.DefaultOutfit.ColorId : (int)DataManager.Player.Customization.Color);
+                    colorChip.Inner.SetHat(hat, __instance.HasLocalPlayer() ? PlayerControl.LocalPlayer.Data.DefaultOutfit.ColorId : DataManager.Player.Customization.Color);
+                    colorChip.transform.localPosition = new Vector3(num, num2, -1f);
                     colorChip.Inner.transform.localPosition = hat.ChipOffset + new Vector2(0f, -0.3f);
                     if (SubmergedCompatibility.Loaded)
                     {
                         colorChip.gameObject.transform.Find("HatParent").transform.localPosition = new Vector3(-0.1f, 0.05f, -2);
                     }
                     colorChip.Tag = hat;
+                    HatCache.Children.Add(hat.ProductId, colorChip.gameObject.transform);
                     __instance.ColorChips.Add(colorChip);
                     hatIdx += 1;
                 }
-
             }
 
+            HatCache.hatIdx = hatIdx;
             __instance.scroller.ContentYBounds.max = -(__instance.YStart - (hatIdx + 1) / __instance.NumPerRow * __instance.YOffset) - 3f;
             __instance.currentHatIsEquipped = true;
 
+            return false;
+        }
+    }
+
+    [HarmonyPatch]
+
+    public class HatsTab_OnDisable
+    {
+        [HarmonyPatch(typeof(InventoryTab), nameof(InventoryTab.OnDisable))]
+
+        public static bool Prefix(InventoryTab __instance)
+        {
+            if (__instance is not HatsTab) return true;
+
+            foreach (var transform in HatCache.Children.Values)
+            {
+                transform.SetParent(HatCache.ChipHolder.transform);
+                transform.gameObject.SetActive(false);
+            }
+
+            __instance.ColorChips.Clear();
             return false;
         }
     }

--- a/source/Patches/CustomHats/CustomHatPatch.cs
+++ b/source/Patches/CustomHats/CustomHatPatch.cs
@@ -88,7 +88,7 @@ namespace TownOfUs.Patches.CustomHats
                 var text = Object.Instantiate(groupNameText, __instance.scroller.Inner);
                 text.gameObject.transform.localScale = Vector3.one;
                 text.GetComponent<TextTranslatorTMP>().Destroy();
-                text.text = groupName;
+                text.text = $"{groupName}\nPress F3 & F4 to cycle pages";
                 text.alignment = TextAlignmentOptions.Center;
                 text.fontSize = 3f;
                 text.fontSizeMax = 3f;

--- a/source/Patches/CustomHats/CustomHatPatch.cs
+++ b/source/Patches/CustomHats/CustomHatPatch.cs
@@ -77,6 +77,8 @@ namespace TownOfUs.Patches.CustomHats
                     var colorChip = Object.Instantiate(__instance.ColorTabPrefab, __instance.scroller.Inner);
                     colorChip.gameObject.name = hat.ProductId;
                     colorChip.Button.OnClick.AddListener((Action)(() => __instance.SelectHat(hat)));
+                    colorChip.Button.OnMouseOver.AddListener((Action)(() => __instance.SelectHat(hat)));
+                    colorChip.Button.OnMouseOut.AddListener((Action)(() => __instance.SelectHat(HatManager.Instance.GetHatById(DataManager.Player.Customization.Hat))));
                     colorChip.Inner.SetHat(hat, __instance.HasLocalPlayer() ? PlayerControl.LocalPlayer.Data.DefaultOutfit.ColorId : DataManager.Player.Customization.Color);
                     colorChip.transform.localPosition = new Vector3(num, num2, -1f);
                     colorChip.Inner.transform.localPosition = hat.ChipOffset + new Vector2(0f, -0.3f);
@@ -104,6 +106,7 @@ namespace TownOfUs.Patches.CustomHats
     public class HatsTab_OnDisable
     {
         [HarmonyPatch(typeof(InventoryTab), nameof(InventoryTab.OnDisable))]
+        [HarmonyPrefix]
 
         public static bool Prefix(InventoryTab __instance)
         {
@@ -117,6 +120,23 @@ namespace TownOfUs.Patches.CustomHats
 
             __instance.ColorChips.Clear();
             return false;
+        }
+
+        [HarmonyPatch(typeof(PlayerCustomizationMenu), nameof(PlayerCustomizationMenu.OpenTab))]
+        [HarmonyPrefix]
+
+        public static void Prefix(ref InventoryTab tab)
+        {
+            if (tab is HatsTab hattab && hattab.ColorChips.Count == 0)
+            {
+                foreach (var transform in HatCache.Children.Values)
+                {
+                    if (transform.gameObject.GetComponent<ColorChip>())
+                    {
+                        hattab.ColorChips.Add(transform.gameObject.GetComponent<ColorChip>());
+                    }
+                }
+            }
         }
     }
 }

--- a/source/Patches/CustomHats/CustomHatPatch.cs
+++ b/source/Patches/CustomHats/CustomHatPatch.cs
@@ -16,6 +16,10 @@ namespace TownOfUs.Patches.CustomHats
 
     public static class HatsTab_OnEnable
     {
+        public static int CurrentPage = 0;
+
+        public static string LastHeader = string.Empty;
+        
         [HarmonyPatch(typeof(HatsTab), nameof(HatsTab.OnEnable))]
 
         public static bool Prefix(HatsTab __instance)
@@ -25,33 +29,60 @@ namespace TownOfUs.Patches.CustomHats
 
             if (HatCache.SortedHats == null)
             {
+                var num = 0;
                 HatCache.SortedHats = new(new PaddedComparer<string>("Vanilla", ""));
                 foreach (var hat in allHats)
                 {
                     if (!HatCache.SortedHats.ContainsKey(hat.StoreName)) HatCache.SortedHats[hat.StoreName] = [];
                     HatCache.SortedHats[hat.StoreName].Add(hat);
+
+                    if (!HatCache.StoreNames.ContainsValue(hat.StoreName))
+                    {
+                        HatCache.StoreNames.Add(num, hat.StoreName);
+                        num++;
+                    }
                 }
             }
 
-            if (HatCache.Children.Count > 0)
+            GenHats(__instance, CurrentPage);
+
+            return false;
+        }
+
+        [HarmonyPatch(typeof(HatsTab), nameof(HatsTab.Update))]
+        [HarmonyPrefix]
+
+        public static void Update(HatsTab __instance)
+        {
+            if (Input.GetKeyDown(KeyCode.F3))
             {
-                HatCache.Children.Values.Do(x =>
-                {
-                    x.transform.SetParent(__instance.scroller.Inner);
-                    x.gameObject.SetActive(true);
-                });
-                __instance.scroller.ContentYBounds.max = -(__instance.YStart - (HatCache.hatIdx + 1) / __instance.NumPerRow * __instance.YOffset) - 3f;
-                __instance.currentHatIsEquipped = true;
-
-                return false;
+                CurrentPage--;
+                CurrentPage = CurrentPage < 0 ? HatCache.StoreNames.Count - 1 : CurrentPage;
+                GenHats(__instance, CurrentPage);
             }
+            else if (Input.GetKeyDown(KeyCode.F4))
+            {
+                CurrentPage++;
+                CurrentPage = CurrentPage > HatCache.StoreNames.Count - 1 ? 0 : CurrentPage;
+                GenHats(__instance, CurrentPage);
+            }
+        }
 
+        public static void GenHats(HatsTab __instance, int page)
+        {
             foreach (ColorChip instanceColorChip in __instance.ColorChips) instanceColorChip.gameObject.Destroy();
             __instance.ColorChips.Clear();
 
+            if (LastHeader != string.Empty)
+            {
+                var header = GameObject.Find(LastHeader);
+                if (header != null) header.Destroy();
+            }
+
             var groupNameText = __instance.GetComponentInChildren<TextMeshPro>(false);
             int hatIdx = 0;
-            foreach ((string groupName, List<HatData> hats) in HatCache.SortedHats)
+            var group = HatCache.SortedHats.Where(x => x.Key == HatCache.StoreNames[page]);
+            foreach ((string groupName, List<HatData> hats) in group)
             {
                 hatIdx = (hatIdx + 4) / 5 * 5;
                 var text = Object.Instantiate(groupNameText, __instance.scroller.Inner);
@@ -62,11 +93,10 @@ namespace TownOfUs.Patches.CustomHats
                 text.fontSize = 3f;
                 text.fontSizeMax = 3f;
                 text.fontSizeMin = 0f;
-                text.name = $"{groupName} header";
+                LastHeader = text.name = $"{groupName} header";
                 float xLerp = __instance.XRange.Lerp(0.5f);
                 float yLerp = __instance.YStart - hatIdx / __instance.NumPerRow * __instance.YOffset;
                 text.transform.localPosition = new Vector3(xLerp, yLerp, -1f);
-                HatCache.Children.Add(groupName, text.transform);
 
                 hatIdx += 5;
                 foreach (var hat in hats.OrderBy(HatManager.Instance.allHats.IndexOf))
@@ -77,8 +107,6 @@ namespace TownOfUs.Patches.CustomHats
                     var colorChip = Object.Instantiate(__instance.ColorTabPrefab, __instance.scroller.Inner);
                     colorChip.gameObject.name = hat.ProductId;
                     colorChip.Button.OnClick.AddListener((Action)(() => __instance.SelectHat(hat)));
-                    colorChip.Button.OnMouseOver.AddListener((Action)(() => __instance.SelectHat(hat)));
-                    colorChip.Button.OnMouseOut.AddListener((Action)(() => __instance.SelectHat(HatManager.Instance.GetHatById(DataManager.Player.Customization.Hat))));
                     colorChip.Inner.SetHat(hat, __instance.HasLocalPlayer() ? PlayerControl.LocalPlayer.Data.DefaultOutfit.ColorId : DataManager.Player.Customization.Color);
                     colorChip.transform.localPosition = new Vector3(num, num2, -1f);
                     colorChip.Inner.transform.localPosition = hat.ChipOffset + new Vector2(0f, -0.3f);
@@ -87,56 +115,13 @@ namespace TownOfUs.Patches.CustomHats
                         colorChip.gameObject.transform.Find("HatParent").transform.localPosition = new Vector3(-0.1f, 0.05f, -2);
                     }
                     colorChip.Tag = hat;
-                    HatCache.Children.Add(hat.ProductId, colorChip.gameObject.transform);
                     __instance.ColorChips.Add(colorChip);
                     hatIdx += 1;
                 }
             }
 
-            HatCache.hatIdx = hatIdx;
             __instance.scroller.ContentYBounds.max = -(__instance.YStart - (hatIdx + 1) / __instance.NumPerRow * __instance.YOffset) - 3f;
             __instance.currentHatIsEquipped = true;
-
-            return false;
-        }
-    }
-
-    [HarmonyPatch]
-
-    public class HatsTab_OnDisable
-    {
-        [HarmonyPatch(typeof(InventoryTab), nameof(InventoryTab.OnDisable))]
-        [HarmonyPrefix]
-
-        public static bool Prefix(InventoryTab __instance)
-        {
-            if (__instance is not HatsTab) return true;
-
-            foreach (var transform in HatCache.Children.Values)
-            {
-                transform.SetParent(HatCache.ChipHolder.transform);
-                transform.gameObject.SetActive(false);
-            }
-
-            __instance.ColorChips.Clear();
-            return false;
-        }
-
-        [HarmonyPatch(typeof(PlayerCustomizationMenu), nameof(PlayerCustomizationMenu.OpenTab))]
-        [HarmonyPrefix]
-
-        public static void Prefix(ref InventoryTab tab)
-        {
-            if (tab is HatsTab hattab && hattab.ColorChips.Count == 0)
-            {
-                foreach (var transform in HatCache.Children.Values)
-                {
-                    if (transform.gameObject.GetComponent<ColorChip>())
-                    {
-                        hattab.ColorChips.Add(transform.gameObject.GetComponent<ColorChip>());
-                    }
-                }
-            }
         }
     }
 }

--- a/source/Patches/CustomHats/CustomHatPatch.cs
+++ b/source/Patches/CustomHats/CustomHatPatch.cs
@@ -106,7 +106,9 @@ namespace TownOfUs.Patches.CustomHats
 
                     var colorChip = Object.Instantiate(__instance.ColorTabPrefab, __instance.scroller.Inner);
                     colorChip.gameObject.name = hat.ProductId;
-                    colorChip.Button.OnClick.AddListener((Action)(() => __instance.SelectHat(hat)));
+                    colorChip.Button.OnClick.AddListener((Action)(() => __instance.ClickEquip()));
+                    colorChip.Button.OnMouseOver.AddListener((Action)(() => __instance.SelectHat(hat)));
+                    colorChip.Button.OnMouseOut.AddListener((Action)(() => __instance.SelectHat(HatManager.Instance.GetHatById(DataManager.Player.Customization.Hat))));
                     colorChip.Inner.SetHat(hat, __instance.HasLocalPlayer() ? PlayerControl.LocalPlayer.Data.DefaultOutfit.ColorId : DataManager.Player.Customization.Color);
                     colorChip.transform.localPosition = new Vector3(num, num2, -1f);
                     colorChip.Inner.transform.localPosition = hat.ChipOffset + new Vector2(0f, -0.3f);

--- a/source/Patches/CustomHats/HatCache.cs
+++ b/source/Patches/CustomHats/HatCache.cs
@@ -5,8 +5,12 @@ namespace TownOfUs.Patches.CustomHats
 {
     public static class HatCache
     {
-        public static Dictionary<string, Sprite> hatViewDatas= new Dictionary<string, Sprite>();
-
+        public static SortedList<string, List<HatData>> SortedHats = null;
         
+        public static GameObject ChipHolder = null;
+
+        public static Dictionary<string, Transform> Children = [];
+
+        public static int hatIdx = 0;
     }
 }

--- a/source/Patches/CustomHats/HatCache.cs
+++ b/source/Patches/CustomHats/HatCache.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using UnityEngine;
 
 namespace TownOfUs.Patches.CustomHats
 {
@@ -7,10 +6,6 @@ namespace TownOfUs.Patches.CustomHats
     {
         public static SortedList<string, List<HatData>> SortedHats = null;
         
-        public static GameObject ChipHolder = null;
-
-        public static Dictionary<string, Transform> Children = [];
-
-        public static int hatIdx = 0;
+        public static Dictionary<int, string> StoreNames = [];
     }
 }

--- a/source/Patches/CustomHats/HatLoader.cs
+++ b/source/Patches/CustomHats/HatLoader.cs
@@ -6,6 +6,7 @@ using BepInEx.Logging;
 using Reactor.Utilities;
 using System.Linq;
 using UnityEngine.AddressableAssets;
+using Reactor.Utilities.Extensions;
 
 namespace TownOfUs.Patches.CustomHats
 {
@@ -18,8 +19,7 @@ namespace TownOfUs.Patches.CustomHats
 
         internal static void LoadHatsRoutine()
         {
-            if (LoadedHats || !DestroyableSingleton<HatManager>.InstanceExists || DestroyableSingleton<HatManager>.Instance.allHats.Count == 0)
-                return;
+            if (LoadedHats || !HatManager.InstanceExists || HatManager.Instance.allHats.Count == 0) return;
             LoadedHats = true;
             Coroutines.Start(LoadHats());
         }
@@ -32,17 +32,23 @@ namespace TownOfUs.Patches.CustomHats
                 var hatBehaviours = DiscoverHatBehaviours();
 
                 var hatData = new List<HatData>();
-                hatData.AddRange(DestroyableSingleton<HatManager>.Instance.allHats);
-                hatData.ForEach((Action<HatData>)(x => x.StoreName = "Vanilla"));
+                hatData.AddRange(HatManager.Instance.allHats);
+                hatData.ForEach(x => x.StoreName = "Vanilla");
 
-                var originalCount = DestroyableSingleton<HatManager>.Instance.allHats.ToList().Count;
+                var originalCount = HatManager.Instance.allHats.ToList().Count;
                 hatBehaviours.Reverse();
                 for (var i = 0; i < hatBehaviours.Count; i++)
                 {
                     hatBehaviours[i].displayOrder = originalCount + i;
                     hatData.Add(hatBehaviours[i]);
                 }
-                DestroyableSingleton<HatManager>.Instance.allHats = hatData.ToArray();
+                HatManager.Instance.allHats = hatData.ToArray();
+
+                if (HatCache.ChipHolder == null)
+                {
+                    HatCache.ChipHolder = new("HatHolder");
+                    HatCache.ChipHolder.DontDestroy();
+                }
             }
             catch (Exception e)
             {

--- a/source/Patches/CustomHats/HatLoader.cs
+++ b/source/Patches/CustomHats/HatLoader.cs
@@ -6,7 +6,6 @@ using BepInEx.Logging;
 using Reactor.Utilities;
 using System.Linq;
 using UnityEngine.AddressableAssets;
-using Reactor.Utilities.Extensions;
 
 namespace TownOfUs.Patches.CustomHats
 {
@@ -43,12 +42,6 @@ namespace TownOfUs.Patches.CustomHats
                     hatData.Add(hatBehaviours[i]);
                 }
                 HatManager.Instance.allHats = hatData.ToArray();
-
-                if (HatCache.ChipHolder == null)
-                {
-                    HatCache.ChipHolder = new("HatHolder");
-                    HatCache.ChipHolder.DontDestroy();
-                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
this pr removes the lag with opening the hat tab after the 1st time opening it. Object instantiating and looping through all the hats is not done after the 1st time once all the hats are cached. The hats then change parents between the hat tab and 1 of our own objects

current known bug with unknown solution: when changing from the any tab to the hat tab after the first time, an System.ArgumentException is thrown, and the previous's tab's contents also show up.

changing from color -> hat or hat -> any other tab is fine
changing from any tab except color -> hats causes a visual bug
the user has to go to color first to get to hats