### PR TITLE
set long body in camo comms properly

### DIFF
--- a/source/Patches/AprilFools_LongBoi.cs
+++ b/source/Patches/AprilFools_LongBoi.cs
@@ -11,4 +11,11 @@ public static class LongBoiPatches
     {
         while (colorIndex >= __instance.heightsPerColor.Count) colorIndex -= __instance.heightsPerColor.Count;
     }
+
+    [HarmonyPatch(nameof(LongBoiPlayerBody.GrowNeck))]
+    [HarmonyPrefix]
+    public static bool LongBoy_GrowNeckPatch()
+    {
+        return !CamouflageUnCamouflage.IsCamoed;
+    }
 }

--- a/source/Patches/Utils.cs
+++ b/source/Patches/Utils.cs
@@ -66,6 +66,11 @@ namespace TownOfUs
                         PlayerName = " ",
                         PetId = ""
                     });
+                    if (AprilFoolsMode.ShouldLongAround())
+                    {
+                        player.cosmetics.currentBodySprite.LongModeParts.Do(x => PlayerMaterial.SetColors(Color.grey, x));
+                        player.cosmetics.GetLongBoi().ResetNeck();
+                    }
                     PlayerMaterial.SetColors(Color.grey, player.myRend());
                     player.nameText().color = Color.clear;
                     player.cosmetics.colorBlindText.color = Color.clear;


### PR DESCRIPTION
sets the whole body to be gray now and also resets the necks so you cant remember by the length