### PR TITLE
Fix Vampire endgame

### DIFF
--- a/source/Patches/Roles/Vampire.cs
+++ b/source/Patches/Roles/Vampire.cs
@@ -40,6 +40,9 @@ namespace TownOfUs.Roles
                     PlayerControl.AllPlayerControls.ToArray().Count(x => !x.Data.IsDead && !x.Data.Disconnected &&
                     (x.Data.IsImpostor() || x.Is(Faction.NeutralKilling))) == 1)
             {
+                var vampsAlives = PlayerControl.AllPlayerControls.ToArray()
+                    .Where(x => !x.Data.IsDead && !x.Data.Disconnected && x.Is(RoleEnum.Vampire)).ToList();
+                if (vampsAlives.Count == 0) return false;
                 VampWin();
                 Utils.EndGame();
                 return false;

--- a/source/Patches/Roles/Vampire.cs
+++ b/source/Patches/Roles/Vampire.cs
@@ -44,7 +44,7 @@ namespace TownOfUs.Roles
                     (x.Data.IsImpostor() || x.Is(Faction.NeutralKilling)) && !x.Is(RoleEnum.Vampire)) > 0) return false;
             // Can't win if living players outnumber living Vampires
             var playersAlive = PlayerControl.AllPlayerControls.ToArray().Count(x => !x.Data.IsDead && !x.Data.Disconnected);
-            if (vampsAlives.Count < Math.Ceiling((double)(playersAlive / 2))) return false;
+            if (vampsAlives.Count < Math.Ceiling((double)(playersAlive / 2f))) return false;
             // No other killers are alive and Vampires are equal to or greater in number than the living, so they win
             VampWin();
             Utils.EndGame();

--- a/source/Patches/Roles/Vampire.cs
+++ b/source/Patches/Roles/Vampire.cs
@@ -35,47 +35,20 @@ namespace TownOfUs.Roles
         internal override bool NeutralWin(LogicGameFlowNormal __instance)
         {
             if (Player.Data.IsDead || Player.Data.Disconnected) return true;
-
-            if (PlayerControl.AllPlayerControls.ToArray().Count(x => !x.Data.IsDead && !x.Data.Disconnected) <= 2 &&
-                    PlayerControl.AllPlayerControls.ToArray().Count(x => !x.Data.IsDead && !x.Data.Disconnected &&
-                    (x.Data.IsImpostor() || x.Is(Faction.NeutralKilling))) == 1)
-            {
-                var vampsAlives = PlayerControl.AllPlayerControls.ToArray()
-                    .Where(x => !x.Data.IsDead && !x.Data.Disconnected && x.Is(RoleEnum.Vampire)).ToList();
-                if (vampsAlives.Count == 0) return false;
-                VampWin();
-                Utils.EndGame();
-                return false;
-            }
-            else if (PlayerControl.AllPlayerControls.ToArray().Count(x => !x.Data.IsDead && !x.Data.Disconnected) <= 4 &&
-                    PlayerControl.AllPlayerControls.ToArray().Count(x => !x.Data.IsDead && !x.Data.Disconnected &&
-                    (x.Data.IsImpostor() || x.Is(Faction.NeutralKilling)) && !x.Is(RoleEnum.Vampire)) == 0)
-            {
-                var vampsAlives = PlayerControl.AllPlayerControls.ToArray()
-                    .Where(x => !x.Data.IsDead && !x.Data.Disconnected && x.Is(RoleEnum.Vampire)).ToList();
-                if (vampsAlives.Count == 1) return false;
-                VampWin();
-                Utils.EndGame();
-                return false;
-            }
-            else
-            {
-                var vampsAlives = PlayerControl.AllPlayerControls.ToArray()
-                    .Where(x => !x.Data.IsDead && !x.Data.Disconnected && x.Is(RoleEnum.Vampire)).ToList();
-                if (vampsAlives.Count == 1 || vampsAlives.Count == 2) return false;
-                var alives = PlayerControl.AllPlayerControls.ToArray()
-                    .Where(x => !x.Data.IsDead && !x.Data.Disconnected).ToList();
-                var killersAlive = PlayerControl.AllPlayerControls.ToArray()
-                    .Where(x => !x.Data.IsDead && !x.Data.Disconnected && !x.Is(RoleEnum.Vampire) && (x.Is(Faction.Impostors) || x.Is(Faction.NeutralKilling))).ToList();
-                if (killersAlive.Count > 0) return false;
-                if (alives.Count <= 6)
-                {
-                    VampWin();
-                    Utils.EndGame();
-                    return false;
-                }
-                return false;
-            }
+            // Can't win if no Vampires are alive
+            var vampsAlives = PlayerControl.AllPlayerControls.ToArray()
+                .Where(x => !x.Data.IsDead && !x.Data.Disconnected && x.Is(RoleEnum.Vampire)).ToList();
+            if (vampsAlives.Count == 0) return false;
+            // Can't win if any other killers are still alive
+            if (PlayerControl.AllPlayerControls.ToArray().Count(x => !x.Data.IsDead && !x.Data.Disconnected &&
+                    (x.Data.IsImpostor() || x.Is(Faction.NeutralKilling)) && !x.Is(RoleEnum.Vampire)) > 0) return false;
+            // Can't win if living players outnumber living Vampires
+            var playersAlive = PlayerControl.AllPlayerControls.ToArray().Count(x => !x.Data.IsDead && !x.Data.Disconnected);
+            if (vampsAlives.Count < Math.Ceiling((double)(playersAlive / 2))) return false;
+            // No other killers are alive and Vampires are equal to or greater in number than the living, so they win
+            VampWin();
+            Utils.EndGame();
+            return false;
         }
 
         protected override void IntroPrefix(IntroCutscene._ShowTeam_d__38 __instance)


### PR DESCRIPTION
Closes #247 by preventing the Vampires from winning in final 2 if all Vampires are dead.

Also rewrites the logic for Vampire NeutralWin so that it's not so spaghetti in general.