### PR TITLE
Implement Weighted Role Selection System (Related to issue #252)

### DIFF
--- a/source/Extensions/AmongUsExtensions.cs
+++ b/source/Extensions/AmongUsExtensions.cs
@@ -132,5 +132,11 @@ namespace TownOfUs.Extensions
         public static TMPro.TextMeshPro NameText(this PoolablePlayer p) => p.cosmetics.nameText;
 
         public static UnityEngine.SpriteRenderer myRend(this PlayerControl p) => p.cosmetics.currentBodySprite.BodySprite;
+
+        // Add a method to calculate weighted role probabilities based on the session's role history.
+        public static Dictionary<RoleEnum, float> CalculateWeightedRoleProbabilities(PlayerControl player) {
+            // Placeholder for actual implementation
+            return new Dictionary<RoleEnum, float>();
+        }       
     }
 }

--- a/source/Patches/AmongUsClient_OnGameEnd.cs
+++ b/source/Patches/AmongUsClient_OnGameEnd.cs
@@ -10,8 +10,29 @@ namespace TownOfUs
     [HarmonyPatch(typeof(EndGameManager), nameof(EndGameManager.Start))]
     public class EndGameManager_SetEverythingUp
     {
+        // Implement a method to record the roles assigned to each player at the end of a game.
+        // Store the role history in a session-based collection.
+        private static Dictionary<byte, List<RoleEnum>> _sessionRoleHistory = new Dictionary<byte, List<RoleEnum>>();
+
+        public static void RecordSessionRoles() {
+            foreach (var player in PlayerControl.AllPlayerControls) {
+                var playerId = player.PlayerId;
+                var roleType = Role.GetRole(player)?.RoleType ?? RoleEnum.None;
+
+                if (!_sessionRoleHistory.ContainsKey(playerId)) {
+                    _sessionRoleHistory[playerId] = new List<RoleEnum>();
+                }
+
+                _sessionRoleHistory[playerId].Add(roleType);
+            }
+        }
+
         public static void Prefix()
         {
+          if (CustomGameOptions.WeightedRoleSelection)  
+          { 
+              RecordSessionRoles(); // Record roles at the end of each game
+          }
             List<int> losers = new List<int>();
             foreach (var role in Role.GetRoles(RoleEnum.Amnesiac))
             {

--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -30,6 +30,9 @@ namespace TownOfUs
     }
     public static class CustomGameOptions
     {
+        // Define a new game option to enable or disable the weighted role selection system.
+        public static bool WeightedRoleSelection = Generate.WeightedRoleSelection.Get();
+
         public static int MayorOn => (int)Generate.MayorOn.Get();
         public static int JesterOn => (int)Generate.JesterOn.Get();
         public static int SheriffOn => (int)Generate.SheriffOn.Get();

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -505,6 +505,8 @@ namespace TownOfUs.CustomOption
         public static CustomNumberOption ChillDuration;
         public static CustomNumberOption ChillStartSpeed;
 
+        public static CustomToggleOption WeightedRoleSelection;
+
         public static Func<object, string> PercentFormat { get; } = value => $"{value:0}%";
         private static Func<object, string> CooldownFormat { get; } = value => $"{value:0.0#}s";
         private static Func<object, string> MultiplierFormat { get; } = value => $"{value:0.0#}x";
@@ -1297,7 +1299,6 @@ namespace TownOfUs.CustomOption
             Frosty = new CustomHeaderOption(num++, MultiMenu.modifiers, "<color=#99FFFFFF>Frosty</color>");
             ChillDuration = new CustomNumberOption(num++, MultiMenu.modifiers, "Chill Duration", 10f, 1f, 15f, 1f, CooldownFormat);
             ChillStartSpeed = new CustomNumberOption(num++, MultiMenu.modifiers, "Chill Start Speed", 0.75f, 0.25f, 0.95f, 0.05f, MultiplierFormat);
-
             Flash = new CustomHeaderOption(num++, MultiMenu.modifiers, "<color=#FF8080FF>Flash</color>");
             FlashSpeed = new CustomNumberOption(num++, MultiMenu.modifiers, "Flash Speed", 1.25f, 1.05f, 2.5f, 0.05f, MultiplierFormat);
 
@@ -1314,6 +1315,8 @@ namespace TownOfUs.CustomOption
             Underdog = new CustomHeaderOption(num++, MultiMenu.modifiers, "<color=#FF0000FF>Underdog</color>");
             UnderdogKillBonus = new CustomNumberOption(num++, MultiMenu.modifiers, "Kill Cooldown Bonus", 5f, 2.5f, 10f, 2.5f, CooldownFormat);
             UnderdogIncreasedKC = new CustomToggleOption(num++, MultiMenu.modifiers, "Increased Kill Cooldown When 2+ Imps", true);
+
+            WeightedRoleSelection = new CustomToggleOption(num++, MultiMenu.main, "Record Roles On each game ends (weighted role selection)", true);
         }
     }
 }


### PR DESCRIPTION
Related to #252

Implements a weighted role selection system to adjust player roles based on previous game outcomes, enhancing the game experience by reducing role repetition for players across sessions.

-  [x] Adds a new game option to enable or disable the weighted role selection system, allowing hosts to control this feature in game settings.
- [x] Records each player's role at the end of a game and stores this information in a session-based collection to calculate future role assignments.
- [x] Updates the role assignment logic to consider the session's role history, aiming to assign roles less repetitively.

---
**if there any thing to do modify or something else feel free to ask me**

@Enduriel