### PR TITLE
Investigator Rework

### DIFF
--- a/source/Patches/CrewmateRoles/InvestigatorMod/AddPrints.cs
+++ b/source/Patches/CrewmateRoles/InvestigatorMod/AddPrints.cs
@@ -29,22 +29,21 @@ namespace TownOfUs.CrewmateRoles.InvestigatorMod
             if (_time >= Interval)
             {
                 _time -= Interval;
-                foreach (var player in PlayerControl.AllPlayerControls)
-                {
-                    if (player == null || player.Data.IsDead ||
-                        player.PlayerId == PlayerControl.LocalPlayer.PlayerId) continue;
+                    if (!(investigator.InvestigatedPlayer == null || investigator.InvestigatedPlayer.Data.IsDead ||
+                        investigator.InvestigatedPlayer.PlayerId == PlayerControl.LocalPlayer.PlayerId))
+                    {
                     var canPlace = !investigator.AllPrints.Any(print =>
-                        Vector3.Distance(print.Position, Position(player)) < 0.5f &&
+                        Vector3.Distance(print.Position, Position(investigator.InvestigatedPlayer)) < 0.5f &&
                         print.Color.a > 0.5 &&
-                        print.Player.PlayerId == player.PlayerId);
+                        print.Player.PlayerId == investigator.InvestigatedPlayer.PlayerId);
 
                     if (Vent && ShipStatus.Instance != null)
                         if (ShipStatus.Instance.AllVents.Any(vent =>
-                            Vector2.Distance(vent.gameObject.transform.position, Position(player)) < 1f))
+                            Vector2.Distance(vent.gameObject.transform.position, Position(investigator.InvestigatedPlayer)) < 1f))
                             canPlace = false;
 
-                    if (canPlace) new Footprint(player, investigator);
-                }
+                    if (canPlace) new Footprint(investigator.InvestigatedPlayer, investigator);
+                    }
 
                 for (var i = 0; i < investigator.AllPrints.Count; i++)
                 {

--- a/source/Patches/CrewmateRoles/InvestigatorMod/Footprint.cs
+++ b/source/Patches/CrewmateRoles/InvestigatorMod/Footprint.cs
@@ -2,7 +2,6 @@ using TownOfUs.Roles;
 using UnityEngine;
 using TownOfUs.Extensions;
 using TownOfUs.Patches;
-
 namespace TownOfUs.CrewmateRoles.InvestigatorMod
 {
     public class Footprint
@@ -12,36 +11,27 @@ namespace TownOfUs.CrewmateRoles.InvestigatorMod
         private SpriteRenderer _spriteRenderer;
         private readonly float _time;
         private readonly Vector2 _velocity;
-
         public Color Color;
         public Vector3 Position;
         public Investigator Role;
-
         public Footprint(PlayerControl player, Investigator role)
         {
             Role = role;
             Position = player.transform.position;
             _velocity = player.gameObject.GetComponent<Rigidbody2D>().velocity;
-
             Player = player;
             _time = (int) Time.time;
             Color = Color.black;
-
             Start();
             role.AllPrints.Add(this);
         }
 
         public static float Duration => CustomGameOptions.FootprintDuration;
 
-        public static bool Grey =>
-            CustomGameOptions.AnonymousFootPrint || CamouflageUnCamouflage.IsCamoed;
-
         public static void DestroyAll(Investigator role)
         {
             while (role.AllPrints.Count != 0) role.AllPrints[0].Destroy();
         }
-
-
         private void Start()
         {
             _gameObject = new GameObject("Footprint");
@@ -49,45 +39,36 @@ namespace TownOfUs.CrewmateRoles.InvestigatorMod
             _gameObject.transform.position = Position;
             _gameObject.transform.Rotate(Vector3.forward * Vector2.SignedAngle(Vector2.up, _velocity));
             _gameObject.transform.SetParent(Player.transform.parent);
-
             _spriteRenderer = _gameObject.AddComponent<SpriteRenderer>();
             _spriteRenderer.sprite = TownOfUs.Footprint;
             _spriteRenderer.color = Color;
             _gameObject.transform.localScale *= new Vector2(1.2f, 1f) * (CustomGameOptions.FootprintSize / 10);
-
             _gameObject.SetActive(true);
         }
-
         private void Destroy()
         {
             Object.Destroy(_gameObject);
             Role.AllPrints.Remove(this);
         }
-
         public bool Update()
         {
             var currentTime = Time.time;
             var alpha = Mathf.Max(1f - (currentTime - _time) / Duration, 0f);
-
             if (alpha < 0 || alpha > 1)
                 alpha = 0;
-            
-            if (RainbowUtils.IsRainbow(Player.GetDefaultOutfit().ColorId) & !Grey)
+
+            if (RainbowUtils.IsRainbow(Player.GetDefaultOutfit().ColorId))
                 Color = RainbowUtils.Rainbow;
-            else if (Grey)
-                Color = new Color(0.2f, 0.2f, 0.2f, 1f);
             else
                 Color = Palette.PlayerColors[Player.GetDefaultOutfit().ColorId];
 
             Color = new Color(Color.r, Color.g, Color.b, alpha);
             _spriteRenderer.color = Color;
-
             if (_time + (int) Duration < currentTime)
             {
                 Destroy();
                 return true;
             }
-
             return false;
         }
     }

--- a/source/Patches/CrewmateRoles/InvestigatorMod/HudInvestigate.cs
+++ b/source/Patches/CrewmateRoles/InvestigatorMod/HudInvestigate.cs
@@ -1,0 +1,79 @@
+﻿using AmongUs.GameOptions;
+using HarmonyLib;
+using Il2CppSystem.Reflection;
+using TownOfUs.Roles;
+using UnityEngine;
+using TownOfUs.Extensions;
+using Reactor.Utilities;
+
+namespace TownOfUs.CrewmateRoles.InvestigatorMod
+{
+    [HarmonyPatch(typeof(HudManager))]
+    public class HudInvestigate
+    {
+
+        [HarmonyPatch(nameof(HudManager.Update))]
+        public static void Postfix(HudManager __instance)
+        {
+            UpdateInvestigateButton(__instance);
+        }
+
+        public static void UpdateInvestigateButton(HudManager __instance)
+        {
+            if (PlayerControl.AllPlayerControls.Count <= 1) return;
+            if (PlayerControl.LocalPlayer == null) return;
+            if (PlayerControl.LocalPlayer.Data == null) return;
+            if (!PlayerControl.LocalPlayer.Is(RoleEnum.Investigator)) return;
+
+            var role = Role.GetRole<Investigator>(PlayerControl.LocalPlayer);
+
+            if (role.ShouldNotify)
+            {
+                role.ShouldRemove = true;
+                Coroutines.Start(Utils.FlashCoroutine(Color.cyan));
+            }
+
+            if (role.InvestigatedPlayer != null)
+            {
+            role.InvestigatedPlayer.myRend().material.SetColor("_VisorColor", Color.cyan);
+            role.InvestigatedPlayer.nameText().color = Color.cyan;
+            if (role.InvestigatedPlayer.Data.IsDead || role.InvestigatedPlayer.Data.Disconnected)
+            {
+                role.PreviouslyInvestigated.Add(role.InvestigatedPlayer.PlayerId);
+                role.InvestigatedPlayer = null;
+                Utils.Rpc(CustomRPC.StopInvestigation, role.Player.PlayerId);
+                role.StartRemoving = false;
+                role.ShouldNotify = false;
+                role.ShouldRemove = false;
+                MeetingStart.RoleList.Clear();
+                MeetingStart.OnCrewRoles.Clear();
+                MeetingStart.OnNeutRoles.Clear();
+                MeetingStart.OnImpRoles.Clear();
+                MeetingStart.SetRole = false;
+                Coroutines.Start(Utils.FlashCoroutine(Color.red));
+            }
+            }
+
+            var InvestigateButton = __instance.KillButton;
+
+            InvestigateButton.gameObject.SetActive((__instance.UseButton.isActiveAndEnabled || __instance.PetButton.isActiveAndEnabled)
+                    && !MeetingHud.Instance && !PlayerControl.LocalPlayer.Data.IsDead
+                    && AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Started);
+
+            InvestigateButton.SetCoolDown(role.InvestigateTimer(), CustomGameOptions.InvestCd);
+            Utils.SetTarget(ref role.ClosestPlayer, InvestigateButton, float.NaN);
+
+            var renderer = InvestigateButton.graphic;
+            if (role.ClosestPlayer != null)
+            {
+                renderer.color = Palette.EnabledColor;
+                renderer.material.SetFloat("_Desat", 0f);
+            }
+            else
+            {
+                renderer.color = Palette.DisabledClear;
+                renderer.material.SetFloat("_Desat", 1f);
+            }
+        }
+    }
+}

--- a/source/Patches/CrewmateRoles/InvestigatorMod/MeetingHudUpdate.cs
+++ b/source/Patches/CrewmateRoles/InvestigatorMod/MeetingHudUpdate.cs
@@ -1,0 +1,30 @@
+using HarmonyLib;
+using TownOfUs.Roles;
+using UnityEngine;
+
+namespace TownOfUs.CrewmateRoles.InvestigatorMod
+{
+    [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.Update))]
+    public static class MeetingHudUpdate
+    {
+        public static void Postfix(MeetingHud __instance)
+        {
+            var localPlayer = PlayerControl.LocalPlayer;
+            var _role = Role.GetRole(localPlayer);
+            if (_role?.RoleType != RoleEnum.Investigator) return;
+            if (localPlayer.Data.IsDead) return;
+            var role = (Investigator)_role;
+            foreach (var state in __instance.playerStates)
+            {
+                var targetId = state.TargetPlayerId;
+                var playerData = Utils.PlayerById(targetId)?.Data;
+                if (playerData == null || playerData.Disconnected)
+                {
+                    role.InvestigatedPlayer = null;
+                    continue;
+                }
+                if (role.InvestigatedPlayer.PlayerId == targetId) state.NameText.color = Color.cyan;
+            }
+        }
+    }
+}

--- a/source/Patches/CrewmateRoles/InvestigatorMod/MeetingStart.cs
+++ b/source/Patches/CrewmateRoles/InvestigatorMod/MeetingStart.cs
@@ -1,0 +1,194 @@
+using HarmonyLib;
+using TownOfUs.CrewmateRoles.ImitatorMod;
+using TownOfUs.Extensions;
+using TownOfUs.Roles;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+
+namespace TownOfUs.CrewmateRoles.InvestigatorMod
+{
+
+    [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.Start))]
+    public class MeetingStart
+    {
+        public static List<RoleEnum> RoleList = new List<RoleEnum>();
+        public static List<RoleEnum> OnCrewRoles = new List<RoleEnum>();
+        public static List<RoleEnum> OnNeutRoles = new List<RoleEnum>();
+        public static List<RoleEnum> OnImpRoles = new List<RoleEnum>();
+        public static List<RoleEnum> FakeRole = new List<RoleEnum>();
+        public static bool SetRole {get; set;} = false;
+
+        public static RoleEnum LastRole;
+        public static void Postfix(MeetingHud __instance)
+        {
+            if (PlayerControl.LocalPlayer.Data.IsDead) return;
+            if (!PlayerControl.LocalPlayer.Is(RoleEnum.Investigator)) return;
+            var role = Role.GetRole<Investigator>(PlayerControl.LocalPlayer);
+            if (role.InvestigatedPlayer != null)
+            {
+                var playerResults = PlayerReportFeedback(role);
+
+                if (!string.IsNullOrWhiteSpace(playerResults)) DestroyableSingleton<HudManager>.Instance.Chat.AddChat(PlayerControl.LocalPlayer, playerResults);
+            }
+        }
+
+        public static string PlayerReportFeedback(Investigator investigator)
+        {
+            if (LastRole != Role.GetRole(investigator.InvestigatedPlayer).RoleType && SetRole)
+            {
+                investigator.ShouldRemove = false;
+                investigator.StartRemoving = false;
+            }
+            if (investigator.PreviouslyInvestigated.Contains(investigator.InvestigatedPlayer.PlayerId) && Role.GetRole(investigator.InvestigatedPlayer).PossibleRoles.Count() > 0)
+            {
+                string basestring = $"You decided to investigate {investigator.InvestigatedPlayer.name} again.\n";
+                Role.GetRole(investigator.InvestigatedPlayer).PossibleRoles.Clear();
+                SetRole = true;
+                LastRole = Role.GetRole(investigator.InvestigatedPlayer).RoleType;
+                return basestring + RoleList.Join();
+            }
+            else if (!investigator.StartRemoving && investigator.InvestigatedPlayer != null)
+            {
+                investigator.StartRemoving = true;
+                string basestring = $"You investigated {investigator.InvestigatedPlayer.name} and found out they are either:\n";
+
+                if (LastRole != Role.GetRole(investigator.InvestigatedPlayer).RoleType && SetRole) 
+                basestring = $"You noticed {investigator.InvestigatedPlayer.name}'s acting differently, they must have changed their role!\n";
+
+                if (CustomGameOptions.ArsonistOn > 0) OnNeutRoles.Add(RoleEnum.Arsonist);
+                if (CustomGameOptions.BlackmailerOn > 0) OnImpRoles.Add(RoleEnum.Blackmailer);
+                if (CustomGameOptions.BomberOn > 0) OnImpRoles.Add(RoleEnum.Bomber);
+                if (CustomGameOptions.DetectiveOn > 0) OnCrewRoles.Add(RoleEnum.Detective);
+                if (CustomGameOptions.DoomsayerOn > 0 && !CustomGameOptions.DoomsayerCantObserve) OnNeutRoles.Add(RoleEnum.Doomsayer);
+                if (CustomGameOptions.EscapistOn > 0) OnImpRoles.Add(RoleEnum.Escapist);
+                if (CustomGameOptions.GlitchOn > 0) OnNeutRoles.Add(RoleEnum.Glitch);
+                if (CustomGameOptions.GrenadierOn > 0) OnImpRoles.Add(RoleEnum.Grenadier);
+                if (CustomGameOptions.HunterOn > 0) OnCrewRoles.Add(RoleEnum.Hunter);
+                if (CustomGameOptions.JanitorOn > 0) OnImpRoles.Add(RoleEnum.Janitor);
+                if (CustomGameOptions.HiddenRoles || CustomGameOptions.GameMode == GameMode.AllAny) OnNeutRoles.Add(RoleEnum.Juggernaut);
+                if (CustomGameOptions.MedicOn > 0) OnCrewRoles.Add(RoleEnum.Medic);
+                if (CustomGameOptions.MinerOn > 0) OnImpRoles.Add(RoleEnum.Miner);
+                if (CustomGameOptions.MorphlingOn > 0) OnImpRoles.Add(RoleEnum.Morphling);
+                if (CustomGameOptions.OracleOn > 0) OnCrewRoles.Add(RoleEnum.Oracle);
+                if (CustomGameOptions.PlaguebearerOn > 0) OnNeutRoles.Add(RoleEnum.Pestilence);
+                if (CustomGameOptions.PlaguebearerOn > 0) OnNeutRoles.Add(RoleEnum.Plaguebearer);
+                if (CustomGameOptions.SeerOn > 0) OnCrewRoles.Add(RoleEnum.Seer);
+                if (CustomGameOptions.SheriffOn > 0) OnCrewRoles.Add(RoleEnum.Sheriff);
+                if (CustomGameOptions.SwooperOn > 0) OnImpRoles.Add(RoleEnum.Swooper);
+                if (CustomGameOptions.TrackerOn > 0) OnCrewRoles.Add(RoleEnum.Tracker);
+                if (CustomGameOptions.TraitorOn > 0) OnImpRoles.Add(RoleEnum.Traitor);
+                if (CustomGameOptions.UndertakerOn > 0) OnImpRoles.Add(RoleEnum.Undertaker);
+                if (CustomGameOptions.VampireOn > 0) OnNeutRoles.Add(RoleEnum.Vampire);
+                if (CustomGameOptions.VampireHunterOn > 0) OnCrewRoles.Add(RoleEnum.VampireHunter);
+                if (CustomGameOptions.VenererOn > 0) OnImpRoles.Add(RoleEnum.Venerer);
+                if (CustomGameOptions.WarlockOn > 0) OnImpRoles.Add(RoleEnum.Warlock);
+                if (CustomGameOptions.WerewolfOn > 0) OnNeutRoles.Add(RoleEnum.Werewolf);
+                if (CustomGameOptions.ImitatorOn > 0) OnCrewRoles.Add(RoleEnum.Imitator);
+                OnImpRoles.Add(RoleEnum.Impostor);
+
+                if (investigator.InvestigatedPlayer.Is(Faction.Crewmates)) OnCrewRoles.Remove(Role.GetRole(investigator.InvestigatedPlayer).RoleType);
+                else if (investigator.InvestigatedPlayer.Is(Faction.NeutralBenign)) OnNeutRoles.Remove(Role.GetRole(investigator.InvestigatedPlayer).RoleType);
+                else if (investigator.InvestigatedPlayer.Is(Faction.NeutralEvil)) OnNeutRoles.Remove(Role.GetRole(investigator.InvestigatedPlayer).RoleType);
+                else if (investigator.InvestigatedPlayer.Is(Faction.NeutralKilling)) OnNeutRoles.Remove(Role.GetRole(investigator.InvestigatedPlayer).RoleType);
+                else if (investigator.InvestigatedPlayer.Is(Faction.Impostors)) OnNeutRoles.Remove(Role.GetRole(investigator.InvestigatedPlayer).RoleType);
+                float shouldaddcrew = 0;
+                float shouldaddneut = 0;
+                float shouldaddimp = 0;
+
+                if (investigator.RoleCount == 3)
+                {
+                    shouldaddcrew = 1;
+                    shouldaddneut = 1;
+                    shouldaddimp = 1;
+                }
+                else if (investigator.RoleCount == 4)
+                {
+                    shouldaddcrew = 1;
+                    shouldaddneut = 2;
+                    shouldaddimp = 1;
+                }
+                else if (investigator.RoleCount == 5)
+                {
+                    shouldaddcrew = 2;
+                    shouldaddneut = 2;
+                    shouldaddimp = 1;
+                }
+                else if (investigator.RoleCount == 6)
+                {
+                    shouldaddcrew = 2;
+                    shouldaddneut = 2;
+                    shouldaddimp = 2;
+                }
+                else if (investigator.RoleCount == 7)
+                {
+                    shouldaddcrew = 2;
+                    shouldaddneut = 3;
+                    shouldaddimp = 2;
+                }
+                else if (investigator.RoleCount == 8)
+                {
+                    shouldaddcrew = 3;
+                    shouldaddneut = 3;
+                    shouldaddimp = 2;
+                }
+                if (investigator.InvestigatedPlayer.Is(Faction.Crewmates)) shouldaddcrew--;
+                else if (investigator.InvestigatedPlayer.Is(Faction.NeutralBenign)) shouldaddneut--;
+                else if (investigator.InvestigatedPlayer.Is(Faction.NeutralEvil)) shouldaddneut--;
+                else if (investigator.InvestigatedPlayer.Is(Faction.NeutralKilling)) shouldaddneut--;
+                else if (investigator.InvestigatedPlayer.Is(Faction.Impostors)) shouldaddimp--;
+
+                OnCrewRoles.Shuffle();
+                while (shouldaddcrew > 0)
+                {
+                    RoleList.Add(OnCrewRoles[UnityEngine.Random.RandomRangeInt(0, OnCrewRoles.Count)]);
+                    shouldaddcrew--;
+                }
+                OnNeutRoles.Shuffle();
+                while (shouldaddneut > 0)
+                {
+                    RoleList.Add(OnNeutRoles[UnityEngine.Random.RandomRangeInt(0, OnNeutRoles.Count)]);
+                    shouldaddneut--;
+                }
+                OnImpRoles.Shuffle();
+                while (shouldaddimp > 0)
+                {
+                    RoleList.Add(OnImpRoles[UnityEngine.Random.RandomRangeInt(0, OnImpRoles.Count)]);
+                    shouldaddimp--;
+                }
+                RoleList.Add(Role.GetRole(investigator.InvestigatedPlayer).RoleType);
+                RoleList.Shuffle();
+
+                SetRole = true;
+                LastRole = Role.GetRole(investigator.InvestigatedPlayer).RoleType;
+                return basestring + RoleList.Join();
+            }
+            else if (investigator.ShouldRemove && investigator.InvestigatedPlayer != null)
+            {
+                investigator.ShouldRemove = false;
+                string basestring = $"You were able to narrow down {investigator.InvestigatedPlayer.name}'s role!\n";
+                string cantnarrow = $"You weren't able to narrow down {investigator.InvestigatedPlayer.name}'s role more.\n";
+                int RemoveRoles = RoleList.Count - 2;
+
+                if (investigator.NarrowCount > 0)
+                {
+                    foreach (RoleEnum role in RoleList) FakeRole.Add(role);
+                    FakeRole.Remove(Role.GetRole(investigator.InvestigatedPlayer).RoleType);
+                    while (RemoveRoles > 0)
+                    {
+                        FakeRole.Remove(FakeRole[UnityEngine.Random.RandomRangeInt(0, FakeRole.Count)]);
+                        RemoveRoles--;
+                    }
+                    foreach (RoleEnum role in FakeRole) RoleList.Remove(role);
+                    FakeRole.Clear();
+                }
+
+                LastRole = Role.GetRole(investigator.InvestigatedPlayer).RoleType;
+                SetRole = true;
+                if (investigator.NarrowCount > 0) return basestring + RoleList.Join();
+                else return cantnarrow + RoleList.Join();
+            }
+            else return "You weren't able to gather information";
+        }
+    }
+}

--- a/source/Patches/CrewmateRoles/InvestigatorMod/PerformKill.cs
+++ b/source/Patches/CrewmateRoles/InvestigatorMod/PerformKill.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using HarmonyLib;
+using TownOfUs.Roles;
+using UnityEngine;
+using Reactor.Utilities;
+using AmongUs.GameOptions;
+
+namespace TownOfUs.CrewmateRoles.InvestigatorMod
+{
+    [HarmonyPatch(typeof(KillButton), nameof(KillButton.DoClick))]
+    public class PerformKill
+    {
+        public static bool Prefix(KillButton __instance)
+        {
+            if (!PlayerControl.LocalPlayer.Is(RoleEnum.Investigator)) return true;
+            var role = Role.GetRole<Investigator>(PlayerControl.LocalPlayer);
+            if (PlayerControl.LocalPlayer.Data.IsDead) return false;
+            if (!PlayerControl.LocalPlayer.CanMove) return false;
+            if (!__instance.enabled) return false;
+            var maxDistance = GameOptionsData.KillDistances[GameOptionsManager.Instance.currentNormalGameOptions.KillDistance];
+
+            var flag2 = role.InvestigateTimer() == 0f;
+                if (!flag2) return false;
+                if (role.ClosestPlayer == null) return false;
+                if (Vector2.Distance(role.ClosestPlayer.GetTruePosition(),
+                    PlayerControl.LocalPlayer.GetTruePosition()) > maxDistance) return false;
+                var interact = Utils.Interact(PlayerControl.LocalPlayer, role.ClosestPlayer);
+                if (interact[4] == true)
+                {
+                    if (!role.ClosestPlayer.Is(RoleEnum.Amnesiac) && !role.ClosestPlayer.Is(RoleEnum.Mayor) && !role.ClosestPlayer.Is(RoleEnum.Altruist) && 
+                    !role.ClosestPlayer.Is(RoleEnum.Aurial) && !role.ClosestPlayer.Is(RoleEnum.Vigilante) && !role.ClosestPlayer.Is(RoleEnum.Doomsayer) &&
+                    !role.ClosestPlayer.Is(RoleEnum.Engineer) && !role.ClosestPlayer.Is(RoleEnum.Executioner) && !role.ClosestPlayer.Is(RoleEnum.GuardianAngel) &&
+                    !role.ClosestPlayer.Is(RoleEnum.Jester) && !role.ClosestPlayer.Is(RoleEnum.Medium) && !role.ClosestPlayer.Is(RoleEnum.Crewmate) && 
+                    !role.ClosestPlayer.Is(RoleEnum.Mystic) && !role.ClosestPlayer.Is(RoleEnum.Prosecutor) && !role.ClosestPlayer.Is(RoleEnum.Snitch) &&
+                    !role.ClosestPlayer.Is(RoleEnum.Spy) && !role.ClosestPlayer.Is(RoleEnum.Survivor) && !role.ClosestPlayer.Is(RoleEnum.Swapper) &&
+                    !role.ClosestPlayer.Is(RoleEnum.Transporter) && !role.ClosestPlayer.Is(RoleEnum.Trapper) && !role.ClosestPlayer.Is(RoleEnum.Veteran))
+                    {
+                        if (role.InvestigatedPlayer != null)
+                        {
+                            role.PreviouslyInvestigated.Add(role.InvestigatedPlayer.PlayerId);
+                            foreach (RoleEnum role1 in MeetingStart.RoleList) Role.GetRole(role.InvestigatedPlayer).PossibleRoles.Add(role1);
+                        }
+
+                        role.InvestigatedPlayer = role.ClosestPlayer;
+                        Utils.Rpc(CustomRPC.Investigate, PlayerControl.LocalPlayer.PlayerId, role.ClosestPlayer.PlayerId);
+                        role.LastInvestigated = DateTime.UtcNow;
+                        Coroutines.Start(Utils.FlashCoroutine(Color.green));
+                        role.StartRemoving = false;
+                        role.ShouldNotify = false;
+                        Utils.Rpc(CustomRPC.NotifyInvestigator, PlayerControl.LocalPlayer.PlayerId);
+                        role.ShouldRemove = false;
+                        MeetingStart.RoleList.Clear();
+                    }
+                    else if (role.ClosestPlayer.Is(RoleEnum.Doomsayer) && !CustomGameOptions.DoomsayerCantObserve)
+                    {
+                        if (role.InvestigatedPlayer != null)
+                        {
+                            role.PreviouslyInvestigated.Add(role.InvestigatedPlayer.PlayerId);
+                            foreach (RoleEnum role1 in MeetingStart.RoleList) Role.GetRole(role.InvestigatedPlayer).PossibleRoles.Add(role1);
+                        }
+
+                        role.InvestigatedPlayer = role.ClosestPlayer;
+                        Utils.Rpc(CustomRPC.Investigate, PlayerControl.LocalPlayer.PlayerId, role.ClosestPlayer.PlayerId);
+                        role.LastInvestigated = DateTime.UtcNow;
+                        Coroutines.Start(Utils.FlashCoroutine(Color.green)); 
+                        role.StartRemoving = false;
+                        role.ShouldNotify = false;
+                        Utils.Rpc(CustomRPC.NotifyInvestigator, PlayerControl.LocalPlayer.PlayerId);
+                        role.ShouldRemove = false;
+                        MeetingStart.RoleList.Clear();
+                        MeetingStart.OnCrewRoles.Clear();
+                        MeetingStart.OnNeutRoles.Clear();
+                        MeetingStart.OnImpRoles.Clear();
+                        MeetingStart.SetRole = false;
+                    }
+                    else Coroutines.Start(Utils.FlashCoroutine(Color.red));
+                }
+                if (interact[0] == true)
+                {
+                    role.LastInvestigated = DateTime.UtcNow;
+                    return false;
+                }
+                else if (interact[1] == true)
+                {
+                    role.LastInvestigated = DateTime.UtcNow;
+                    role.LastInvestigated = role.LastInvestigated.AddSeconds(CustomGameOptions.ProtectKCReset - CustomGameOptions.ExamineCd);
+                    return false;
+                }
+                else if (interact[3] == true) return false;
+                return false;
+        }
+    }
+}

--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -113,7 +113,9 @@ namespace TownOfUs
         public static float FootprintSize => Generate.FootprintSize.Get();
         public static float FootprintInterval => Generate.FootprintInterval.Get();
         public static float FootprintDuration => Generate.FootprintDuration.Get();
-        public static bool AnonymousFootPrint => Generate.AnonymousFootPrint.Get();
+        public static int RoleAmount => (int)Generate.RoleAmount.Get();
+        public static float InvestCd => Generate.InvestCd.Get();
+        public static int RemoveRoles => (int)Generate.RemoveRoles.Get();
         public static bool VentFootprintVisible => Generate.VentFootprintVisible.Get();
         public static bool JesterButton => Generate.JesterButton.Get();
         public static bool JesterVent => Generate.JesterVent.Get();

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -207,7 +207,9 @@ namespace TownOfUs.CustomOption
         public static CustomNumberOption FootprintSize;
         public static CustomNumberOption FootprintInterval;
         public static CustomNumberOption FootprintDuration;
-        public static CustomToggleOption AnonymousFootPrint;
+        public static CustomNumberOption RoleAmount;
+        public static CustomNumberOption InvestCd;
+        public static CustomNumberOption RemoveRoles;
         public static CustomToggleOption VentFootprintVisible;
 
         public static CustomHeaderOption Medic;
@@ -858,11 +860,13 @@ namespace TownOfUs.CustomOption
 
             Investigator =
                 new CustomHeaderOption(num++, MultiMenu.crewmate, "<color=#00B3B3FF>Investigator</color>");
+            InvestCd = new CustomNumberOption(num++, MultiMenu.crewmate, "Investigate Cooldown", 25f, 10f, 60f, 2.5f, CooldownFormat);
             FootprintSize = new CustomNumberOption(num++, MultiMenu.crewmate, "Footprint Size", 4f, 1f, 10f, 1f);
             FootprintInterval =
                 new CustomNumberOption(num++, MultiMenu.crewmate, "Footprint Interval", 0.1f, 0.05f, 1f, 0.05f, CooldownFormat);
             FootprintDuration = new CustomNumberOption(num++, MultiMenu.crewmate, "Footprint Duration", 10f, 1f, 15f, 0.5f, CooldownFormat);
-            AnonymousFootPrint = new CustomToggleOption(num++, MultiMenu.crewmate, "Anonymous Footprint", false);
+            RoleAmount = new CustomNumberOption(num++, MultiMenu.crewmate, "Amount Of Roles Given To Investigator", 6f, 3f, 8f, 1f);
+            RemoveRoles = new CustomNumberOption(num++, MultiMenu.crewmate, "Amount Of Roles Investigator Can Check Off", 3f, 0f, 7f, 1f);
             VentFootprintVisible = new CustomToggleOption(num++, MultiMenu.crewmate, "Footprint Vent Visible", false);
 
             Mystic =

--- a/source/Patches/CustomRPC.cs
+++ b/source/Patches/CustomRPC.cs
@@ -75,6 +75,9 @@ namespace TownOfUs
         HunterStalk,
         HunterCatchPlayer,
         Retribution,
+        Investigate,
+        StopInvestigation,
+        NotifyInvestigator,
 
         BypassKill,
         BypassMultiKill,

--- a/source/Patches/KillButtonSprite.cs
+++ b/source/Patches/KillButtonSprite.cs
@@ -40,6 +40,7 @@ namespace TownOfUs
         private static Sprite Stake => TownOfUs.StakeSprite;
         private static Sprite Confess => TownOfUs.ConfessSprite;
         private static Sprite Radiate => TownOfUs.RadiateSprite;
+        private static Sprite PlaceHolder => TownOfUs.PlaceHolderSprite;
 
         private static Sprite Kill;
 
@@ -154,6 +155,11 @@ namespace TownOfUs
             else if (PlayerControl.LocalPlayer.Is(RoleEnum.Aurial))
             {
                 __instance.KillButton.graphic.sprite = Radiate;
+                flag = true;
+            }
+            else if (PlayerControl.LocalPlayer.Is(RoleEnum.Investigator))
+            {
+                __instance.KillButton.graphic.sprite = PlaceHolder;
                 flag = true;
             }
             else

--- a/source/Patches/RandomMap.cs
+++ b/source/Patches/RandomMap.cs
@@ -145,6 +145,7 @@ namespace TownOfUs
             Generate.RadiateCooldown.Set((float)Generate.RadiateCooldown.Value + change, false);
             Generate.ReviveCooldown.Set((float)Generate.ReviveCooldown.Value + change, false);
             Generate.WhisperCooldown.Set((float)Generate.WhisperCooldown.Value + change, false);
+            Generate.InvestCd.Set((float)Generate.InvestCd.Value + change, false);
             GameOptionsManager.Instance.currentNormalGameOptions.KillCooldown += change;
             if (change % 5 != 0)
             {

--- a/source/Patches/Roles/Investigator.cs
+++ b/source/Patches/Roles/Investigator.cs
@@ -1,11 +1,22 @@
 using System.Collections.Generic;
 using TownOfUs.CrewmateRoles.InvestigatorMod;
+using System;
+using Reactor.Utilities;
 
 namespace TownOfUs.Roles
 {
     public class Investigator : Role
     {
         public readonly List<Footprint> AllPrints = new List<Footprint>();
+        public readonly List<byte> PreviouslyInvestigated = new List<byte>();
+        public PlayerControl InvestigatedPlayer;
+        public PlayerControl ClosestPlayer;
+        public DateTime LastInvestigated { get; set; }
+        public bool StartRemoving { get; set; } = false;
+        public int RoleCount { get; set; } = CustomGameOptions.RoleAmount;
+        public int NarrowCount { get; set; } = CustomGameOptions.RemoveRoles;
+        public bool ShouldRemove { get; set; } = false;
+        public bool ShouldNotify { get; set; } = false;
 
 
         public Investigator(PlayerControl player) : base(player)
@@ -17,6 +28,17 @@ namespace TownOfUs.Roles
             RoleType = RoleEnum.Investigator;
             AddToRoleHistory(RoleType);
             Scale = 1.4f;
+            InvestigatedPlayer = null;
+        }
+
+        public float InvestigateTimer()
+        {
+            var utcNow = DateTime.UtcNow;
+            var timeSpan = utcNow - LastInvestigated;
+            var num = CustomGameOptions.InvestCd * 1000f;
+            var flag2 = num - (float)timeSpan.TotalMilliseconds < 0f;
+            if (flag2) return 0;
+            return (num - (float)timeSpan.TotalMilliseconds) / 1000f;
         }
     }
 }

--- a/source/Patches/Roles/Role.cs
+++ b/source/Patches/Roles/Role.cs
@@ -64,6 +64,7 @@ namespace TownOfUs.Roles
         protected internal int IncorrectKills { get; set; } = 0;
         protected internal int CorrectAssassinKills { get; set; } = 0;
         protected internal int IncorrectAssassinKills { get; set; } = 0;
+        protected internal List<RoleEnum> PossibleRoles = new List<RoleEnum>();
 
         public bool Local => PlayerControl.LocalPlayer.PlayerId == Player.PlayerId;
 

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -803,6 +803,26 @@ namespace TownOfUs
                         Role.GetRole<Medic>(medic).ShieldedPlayer = shield;
                         Role.GetRole<Medic>(medic).UsedAbility = true;
                         break;
+                    case CustomRPC.Investigate:
+                        readByte1 = reader.ReadByte();
+                        readByte2 = reader.ReadByte();
+
+                        var investigator = Utils.PlayerById(readByte1);
+                        var investigated = Utils.PlayerById(readByte2);
+                        Role.GetRole<Investigator>(investigator).InvestigatedPlayer = investigated;
+                        break;
+                    case CustomRPC.StopInvestigation:
+                        readByte1 = reader.ReadByte();
+
+                        var investigator1 = Utils.PlayerById(readByte1);
+                        Role.GetRole<Investigator>(investigator1).InvestigatedPlayer = null;
+                        break;
+                    case CustomRPC.NotifyInvestigator:
+                        readByte1 = reader.ReadByte();
+
+                        var investigator2 = Utils.PlayerById(readByte1);
+                        Role.GetRole<Investigator>(investigator2).ShouldNotify = Role.GetRole<Investigator>(investigator2).ShouldNotify ? false : true;
+                        break;
                     case CustomRPC.AttemptSound:
                         var medicId = reader.ReadByte();
                         readByte = reader.ReadByte();

--- a/source/Patches/Start.cs
+++ b/source/Patches/Start.cs
@@ -73,6 +73,13 @@ namespace TownOfUs.Patches
                 hunter.LastKilled = hunter.LastKilled.AddSeconds(CustomGameOptions.InitialCooldowns - CustomGameOptions.HunterKillCd);
             }
 
+            if (PlayerControl.LocalPlayer.Is(RoleEnum.Investigator))
+            {
+                var invest = Role.GetRole<Investigator>(PlayerControl.LocalPlayer);
+                invest.LastInvestigated = DateTime.UtcNow;
+                invest.LastInvestigated = invest.LastInvestigated.AddSeconds(CustomGameOptions.InitialCooldowns - CustomGameOptions.InvestCd);
+            }
+
             if (PlayerControl.LocalPlayer.Is(RoleEnum.VampireHunter))
             {
                 var vh = Role.GetRole<VampireHunter>(PlayerControl.LocalPlayer);

--- a/source/Patches/Utils.cs
+++ b/source/Patches/Utils.cs
@@ -211,6 +211,24 @@ namespace TownOfUs
             });
         }
 
+        public static bool IsInvestigated(this PlayerControl player)
+        {
+            return Role.GetRoles(RoleEnum.Investigator).Any(role =>
+            {
+                var investigated = ((Investigator)role).InvestigatedPlayer;
+                var investigator = (Investigator)role;
+                return investigated != null && player.PlayerId == investigated.PlayerId;
+            });
+        }
+        public static Investigator GetInvestigator(this PlayerControl player)
+        {
+            return Role.GetRoles(RoleEnum.Investigator).FirstOrDefault(role =>
+            {
+                var investigated = ((Investigator)role).InvestigatedPlayer;
+                return investigated != null && player.PlayerId == investigated.PlayerId;
+            }) as Investigator;
+        }
+
         public static List<bool> Interact(PlayerControl player, PlayerControl target, bool toKill = false)
         {
             bool fullCooldownReset = false;
@@ -218,6 +236,11 @@ namespace TownOfUs
             bool survReset = false;
             bool zeroSecReset = false;
             bool abilityUsed = false;
+            if (player.IsInvestigated())
+            {
+                var invest = player.GetInvestigator();
+                Rpc(CustomRPC.NotifyInvestigator, invest.Player.PlayerId);
+            }
             if (target.IsInfected() || player.IsInfected())
             {
                 foreach (var pb in Role.GetRoles(RoleEnum.Plaguebearer)) ((Plaguebearer)pb).RpcSpreadInfection(target, player);

--- a/source/TownOfUs.cs
+++ b/source/TownOfUs.cs
@@ -100,6 +100,7 @@ namespace TownOfUs
         public static Sprite MimicSprite;
         public static Sprite LockSprite;
         public static Sprite StalkSprite;
+        public static Sprite PlaceHolderSprite;
 
         public static Sprite SettingsButtonSprite;
         public static Sprite CrewSettingsButtonSprite;
@@ -199,6 +200,7 @@ namespace TownOfUs
             MimicSprite = CreateSprite("TownOfUs.Resources.Mimic.png");
             LockSprite = CreateSprite("TownOfUs.Resources.Lock.png");
             StalkSprite = CreateSprite("TownOfUs.Resources.Stalk.png");
+            PlaceHolderSprite = CreateSprite("TownOfUs.Resources.Placeholder.png");
 
             SettingsButtonSprite = CreateSprite("TownOfUs.Resources.SettingsButton.png");
             CrewSettingsButtonSprite = CreateSprite("TownOfUs.Resources.Crewmate.png");


### PR DESCRIPTION
Investigator doesn't have an unique play style, it's just a worse/slightly different tracker and it's frankly kind of borinh; so I've decided to rework it. From my testing with both MCI and multiple windows this doesn't have any bugs but can be never too sure so I'd appreciate some extra testing (I will also be testing on my own).

REWORK:

The Investigator can investigate a player of their choosing, when a player is being investigated they will leave footprints behind for the Investigator and if they interact with another player the investigator will be notified. When a meeting is called the investigator will be given {x} amount of roles, one of these will be the investigated players role and the rest will be randomly chosen roles that are able to spawn (faction amounts are hardcoded so you aren't able to get lucky so all the roles are from the same faction unless you start narrowing it down). After the first meeting every time the investigated player interacts with someone the Investigator will check off one of the random roles, they can only narrow down an {x} amount of roles. If the Investigator tries to investigate a role that can't interact with anyone they will get a red flash on their screen and won't be able to investigate them. If the investigated player dies the Investigator will be notified. The Investigator can choose to stop investigating someone at any time.