### PR TITLE
Fix 2 bugs

### DIFF
--- a/source/Patches/TaskPatches.cs
+++ b/source/Patches/TaskPatches.cs
@@ -41,7 +41,7 @@ namespace TownOfUs
         [HarmonyPatch(typeof(Console), nameof(Console.CanUse))]
         private class Console_CanUse
         {
-            private static bool Prefix(Console __instance, [HarmonyArgument(0)] NetworkedPlayerInfo playerInfo, ref float __result)
+            private static bool Prefix(Console __instance, [HarmonyArgument(0)] NetworkedPlayerInfo playerInfo, ref float __result, ref bool canUse, ref bool couldUse)
             {
                 var playerControl = playerInfo.Object;
 
@@ -61,6 +61,8 @@ namespace TownOfUs
                 if (flag && !__instance.AllowImpostor)
                 {
                     __result = float.MaxValue;
+                    canUse = false;
+                    couldUse = false;
                     return false;
                 }
 

--- a/source/Patches/Vent.cs
+++ b/source/Patches/Vent.cs
@@ -78,7 +78,7 @@ namespace TownOfUs
             float num = float.MaxValue;
             PlayerControl playerControl = playerInfo.Object;
 
-            if (GameOptionsManager.Instance.CurrentGameOptions.GameMode == GameModes.Normal) couldUse = CanVent(playerControl, playerInfo) && !playerControl.MustCleanVent(__instance.Id) && (!playerInfo.IsDead || playerControl.inVent) && (playerControl.CanMove || playerControl.inVent);
+            if (GameOptionsManager.Instance.CurrentGameOptions.GameMode == GameModes.Normal) couldUse = CanVent(playerControl, playerInfo) && (!playerInfo.IsDead || playerControl.inVent) && (playerControl.CanMove || playerControl.inVent);
             else if (GameOptionsManager.Instance.CurrentGameOptions.GameMode == GameModes.HideNSeek && playerControl.Data.IsImpostor()) couldUse = false;
             else couldUse = canUse;
 


### PR DESCRIPTION
I'm getting tired of the Tasks-related bugs in tou. So here's two really little patches to fix the yellow outline around tasks when not being a role that should have tasks and the vent not being usable when having the clean vent task. I checked in game and making the vent usable while having the task does not create issues since you can't vent while using the task or use the task while venting.