### PR TITLE
Fix Lag When Joining Lobby

### DIFF
--- a/source/Patches/CustomOption/Patches.cs
+++ b/source/Patches/CustomOption/Patches.cs
@@ -637,7 +637,7 @@ namespace TownOfUs.CustomOption
                 if (PlayerControl.AllPlayerControls.Count < 2 || !AmongUsClient.Instance ||
                     !PlayerControl.LocalPlayer || !AmongUsClient.Instance.AmHost) return;
 
-                Rpc.SendTargetRpc(__instance.myPlayer);
+                Coroutines.Start(Rpc.SendTargetRpc(__instance.myPlayer));
             }
         }
 

--- a/source/Patches/CustomOption/Patches.cs
+++ b/source/Patches/CustomOption/Patches.cs
@@ -629,18 +629,6 @@ namespace TownOfUs.CustomOption
             }
         }
 
-        [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.RpcSyncSettings))]
-        private class PlayerControlPatch
-        {
-            public static void Postfix()
-            {
-                if (PlayerControl.AllPlayerControls.Count < 2 || !AmongUsClient.Instance ||
-                    !PlayerControl.LocalPlayer || !AmongUsClient.Instance.AmHost) return;
-
-                Rpc.SendRpc();
-            }
-        }
-
         [HarmonyPatch(typeof(PlayerPhysics), nameof(PlayerPhysics.CoSpawnPlayer))]
         private class PlayerJoinPatch
         {
@@ -649,7 +637,7 @@ namespace TownOfUs.CustomOption
                 if (PlayerControl.AllPlayerControls.Count < 2 || !AmongUsClient.Instance ||
                     !PlayerControl.LocalPlayer || !AmongUsClient.Instance.AmHost) return;
 
-                Rpc.SendRpc();
+                Rpc.SendTargetRpc(__instance.myPlayer);
             }
         }
 

--- a/source/Patches/CustomOption/Rpc.cs
+++ b/source/Patches/CustomOption/Rpc.cs
@@ -34,6 +34,34 @@ namespace TownOfUs.CustomOption
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
 
+        public static void SendTargetRpc(PlayerControl target, CustomOption optionn = null)
+        {
+            List<CustomOption> options;
+            if (optionn != null)
+                options = new List<CustomOption> {optionn};
+            else
+                options = CustomOption.AllOptions;
+
+            var writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,
+                (byte) CustomRPC.SyncSettingsTarget, SendOption.Reliable);
+            writer.Write(target.PlayerId);
+            foreach (var option in options)
+            {
+                if (writer.Position > 1000) {
+                    AmongUsClient.Instance.FinishRpcImmediately(writer);
+                    writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,
+                        (byte) CustomRPC.SyncSettingsTarget, SendOption.Reliable);
+                    writer.Write(target.PlayerId);
+                }
+                writer.Write(option.ID);
+                if (option.Type == CustomOptionType.Toggle) writer.Write((bool) option.Value);
+                else if (option.Type == CustomOptionType.Number) writer.Write((float) option.Value);
+                else if (option.Type == CustomOptionType.String) writer.Write((int) option.Value);
+            }
+
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+        }
+
         public static void ReceiveRpc(MessageReader reader)
         {
             PluginSingleton<TownOfUs>.Instance.Log.LogInfo("Options received");

--- a/source/Patches/CustomOption/Rpc.cs
+++ b/source/Patches/CustomOption/Rpc.cs
@@ -34,8 +34,10 @@ namespace TownOfUs.CustomOption
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
 
-        public static void SendTargetRpc(PlayerControl target, CustomOption optionn = null)
+        public static IEnumerator SendTargetRpc(PlayerControl target, CustomOption optionn = null)
         {
+            yield return new WaitForSeconds(0.5f);
+
             List<CustomOption> options;
             if (optionn != null)
                 options = new List<CustomOption> {optionn};
@@ -43,14 +45,14 @@ namespace TownOfUs.CustomOption
                 options = CustomOption.AllOptions;
 
             var writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,
-                (byte) CustomRPC.SyncSettingsTarget, SendOption.Reliable);
+                (byte)CustomRPC.SyncSettingsTarget, SendOption.Reliable);
             writer.Write(target.PlayerId);
             foreach (var option in options)
             {
                 if (writer.Position > 1000) {
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
                     writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,
-                        (byte) CustomRPC.SyncSettingsTarget, SendOption.Reliable);
+                        (byte)CustomRPC.SyncSettingsTarget, SendOption.Reliable);
                     writer.Write(target.PlayerId);
                 }
                 writer.Write(option.ID);
@@ -60,6 +62,8 @@ namespace TownOfUs.CustomOption
             }
 
             AmongUsClient.Instance.FinishRpcImmediately(writer);
+
+            yield break;
         }
 
         public static void ReceiveRpc(MessageReader reader)

--- a/source/Patches/CustomRPC.cs
+++ b/source/Patches/CustomRPC.cs
@@ -92,6 +92,7 @@ namespace TownOfUs
         FixAnimation,
         SetPos,
         SetSettings,
+        SyncSeettingsTarget,
         
         RemoveAllBodies,
         CheckMurder,

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -1008,6 +1008,10 @@ namespace TownOfUs
                     case CustomRPC.SyncCustomSettings:
                         Rpc.ReceiveRpc(reader);
                         break;
+                    case CustomRPC.SyncSettingsTarget:
+                        var joined = Utils.PlayerById(reader.ReadByte());
+                        if (joined != null && joined.AmOwner) Rpc.ReceiveRpc(reader);
+                        break;
                     case CustomRPC.AltruistRevive:
                         readByte1 = reader.ReadByte();
                         var altruistPlayer = Utils.PlayerById(readByte1);

--- a/source/Patches/TaskPatches.cs
+++ b/source/Patches/TaskPatches.cs
@@ -41,7 +41,7 @@ namespace TownOfUs
         [HarmonyPatch(typeof(Console), nameof(Console.CanUse))]
         private class Console_CanUse
         {
-            private static bool Prefix(Console __instance, [HarmonyArgument(0)] NetworkedPlayerInfo playerInfo, ref float __result)
+            private static bool Prefix(Console __instance, [HarmonyArgument(0)] NetworkedPlayerInfo playerInfo, ref float __result, ref bool canUse, ref bool couldUse)
             {
                 var playerControl = playerInfo.Object;
 
@@ -61,6 +61,8 @@ namespace TownOfUs
                 if (flag && !__instance.AllowImpostor)
                 {
                     __result = float.MaxValue;
+                    canUse = false;
+                    couldUse = false;
                     return false;
                 }
 

--- a/source/Patches/Vent.cs
+++ b/source/Patches/Vent.cs
@@ -78,7 +78,7 @@ namespace TownOfUs
             float num = float.MaxValue;
             PlayerControl playerControl = playerInfo.Object;
 
-            if (GameOptionsManager.Instance.CurrentGameOptions.GameMode == GameModes.Normal) couldUse = CanVent(playerControl, playerInfo) && !playerControl.MustCleanVent(__instance.Id) && (!playerInfo.IsDead || playerControl.inVent) && (playerControl.CanMove || playerControl.inVent);
+            if (GameOptionsManager.Instance.CurrentGameOptions.GameMode == GameModes.Normal) couldUse = CanVent(playerControl, playerInfo) && (!playerInfo.IsDead || playerControl.inVent) && (playerControl.CanMove || playerControl.inVent);
             else if (GameOptionsManager.Instance.CurrentGameOptions.GameMode == GameModes.HideNSeek && playerControl.Data.IsImpostor()) couldUse = false;
             else couldUse = canUse;
 


### PR DESCRIPTION
I basically removed a useless patch that made the game lag when the host changed vanilla settings and I also added something to remove the lag when another player joins because I was tired of it. I basically cloned the original sendrpc void and added another customrpc with a parameter that would send the settings rpc only to the player that joins. Now players will only lag whenever they join a lobby but not when the host changes vanilla settings, nor when someone else joins.

Edit: this pr contains also the last two patches I added in my last pr ( https://github.com/eDonnes124/Town-Of-Us-R/pull/334 ), just ignore those.