### PR TITLE
Readable "Target" Colors

### DIFF
--- a/source/Patches/CrewmateRoles/HunterMod/HudManagerUpdate.cs
+++ b/source/Patches/CrewmateRoles/HunterMod/HudManagerUpdate.cs
@@ -29,7 +29,7 @@ namespace TownOfUs.CrewmateRoles.HunterMod
                     if (data == null || data.Disconnected || data.IsDead || PlayerControl.LocalPlayer.Data.IsDead)
                         continue;
 
-                    var colour = Color.black;
+                    var colour = new Color(0.02f, 0.28f, 0.21f);
                     if (player.Is(ModifierEnum.Shy)) colour.a = Modifier.GetModifier<Shy>(player).Opacity;
                     player.nameText().color = colour;
                 }

--- a/source/Patches/CrewmateRoles/HunterMod/MeetingHudUpdate.cs
+++ b/source/Patches/CrewmateRoles/HunterMod/MeetingHudUpdate.cs
@@ -24,7 +24,7 @@ namespace TownOfUs.CrewmateRoles.HunterMod
                     role.CaughtPlayers.Remove(player);
                     continue;
                 }
-                if (role.CaughtPlayers.Any(pc => pc.PlayerId == player.PlayerId)) state.NameText.color = Color.black;
+                if (role.CaughtPlayers.Any(pc => pc.PlayerId == player.PlayerId)) state.NameText.color = new Color(0.02f, 0.28f, 0.21f);
             }
         }
     }

--- a/source/Patches/ImpostorRoles/EclipsalMod/HudManagerUpdate.cs
+++ b/source/Patches/ImpostorRoles/EclipsalMod/HudManagerUpdate.cs
@@ -36,8 +36,8 @@ namespace TownOfUs.ImpostorRoles.EclipsalMod
                             continue;
                         if (role.BlindPlayers.Contains(player))
                         {
-                            player.myRend().material.SetColor("_VisorColor", Color.black);
-                            player.nameText().color = Color.black;
+                            player.myRend().material.SetColor("_VisorColor", new Color(0.32f, 0.13f, 0.13f));
+                            player.nameText().color = new Color(0.32f, 0.13f, 0.13f);
                         }
                         else
                         {

--- a/source/Patches/NeutralRoles/ArsonistMod/HudManagerUpdate.cs
+++ b/source/Patches/NeutralRoles/ArsonistMod/HudManagerUpdate.cs
@@ -31,7 +31,7 @@ namespace TownOfUs.NeutralRoles.ArsonistMod
 
                     player.myRend().material.SetColor("_VisorColor", role.Color);
 
-                    var colour = Color.black;
+                    var colour = new Color(0.32f, 0.13f, 0.13f);
                     if (player.Is(ModifierEnum.Shy)) colour.a = Modifier.GetModifier<Shy>(player).Opacity;
                     player.nameText().color = colour;
                 }

--- a/source/Patches/NeutralRoles/ArsonistMod/MeetingHudUpdate.cs
+++ b/source/Patches/NeutralRoles/ArsonistMod/MeetingHudUpdate.cs
@@ -23,7 +23,7 @@ namespace TownOfUs.NeutralRoles.ArsonistMod
                     role.DousedPlayers.Remove(targetId);
                     continue;
                 }
-                if (role.DousedPlayers.Contains(targetId)) state.NameText.color = Color.black;
+                if (role.DousedPlayers.Contains(targetId)) state.NameText.color = new Color(0.52f, 0.20f, 0.07f);
             }
         }
     }

--- a/source/Patches/NeutralRoles/ExecutionerMod/TargetColor.cs
+++ b/source/Patches/NeutralRoles/ExecutionerMod/TargetColor.cs
@@ -28,7 +28,7 @@ namespace TownOfUs.NeutralRoles.ExecutionerMod
         {
             foreach (var player in __instance.playerStates)
                 if (player.TargetPlayerId == role.target.PlayerId)
-                    player.NameText.color = Color.black;
+                    player.NameText.color = new Color(0.32f, 0.21f, 0.14f);
         }
 
         private static void Postfix(HudManager __instance)
@@ -47,7 +47,7 @@ namespace TownOfUs.NeutralRoles.ExecutionerMod
             {
                 if (role.target && role.target.nameText())
                 {
-                    var colour = Color.black;
+                    var colour = new Color(0.32f, 0.21f, 0.14f);
                     if (role.target.Is(ModifierEnum.Shy)) colour.a = Modifier.GetModifier<Shy>(role.target).Opacity;
                     role.target.nameText().color = colour;
                 }

--- a/source/Patches/NeutralRoles/PlaguebearerMod/HudManagerUpdate.cs
+++ b/source/Patches/NeutralRoles/PlaguebearerMod/HudManagerUpdate.cs
@@ -31,7 +31,7 @@ namespace TownOfUs.NeutralRoles.PlaguebearerMod
 
                     player.myRend().material.SetColor("_VisorColor", role.Color);
 
-                    var colour = Color.black;
+                    var colour = new Color(0.32f, 0.38f, 0.20f);
                     if (player.Is(ModifierEnum.Shy)) colour.a = Modifier.GetModifier<Shy>(player).Opacity;
                     player.nameText().color = colour;
                 }

--- a/source/Patches/NeutralRoles/PlaguebearerMod/MeetingHudUpdate.cs
+++ b/source/Patches/NeutralRoles/PlaguebearerMod/MeetingHudUpdate.cs
@@ -23,7 +23,7 @@ namespace TownOfUs.NeutralRoles.PlaguebearerMod
                     role.InfectedPlayers.Remove(targetId);
                     continue;
                 }
-                if (role.InfectedPlayers.Contains(targetId) && role.Player.PlayerId != targetId) state.NameText.color = Color.black;
+                if (role.InfectedPlayers.Contains(targetId) && role.Player.PlayerId != targetId) state.NameText.color = new Color(0.32f, 0.38f, 0.20f);
             }
         }
     }


### PR DESCRIPTION
Affects Hunter, Arsonist, Executioner, Hypnotist, Eclipsal, and Plaguebearer.

Original Suggestion: [Change the infected color for pb](https://discord.com/channels/890249154402586734/1370541901102579803)

#### Why?
Black text on black nameplate... yeah, this fixes that by making them have unique colors for their roles (they're just the role color with a different shade lmao).